### PR TITLE
Create a Spectral Style Guide and a Manifest to Illustrate the Functionality of Style Guides and Conformance Reports

### DIFF
--- a/lint/spectral-sample-styleguide/README.md
+++ b/lint/spectral-sample-styleguide/README.md
@@ -1,6 +1,6 @@
 ## Summary
 
-The following directory contains a sample Spectral style guide that governs violations on OpenAPI Specs, along witha sample OpenAPI spec which violates multiple rules. This example is used to illustrate the functionality of style guides in the API registry as well as the generation of conformance reports. The test-description of this project teaches how to upload the style guide to the registry, upload the manifest to the registry, compute the conformance report, and the conformance report.
+The following directory contains a sample Spectral style guide that governs violations on OpenAPI Specs, along witha sample OpenAPI spec which violates multiple rules. This example is used to illustrate the functionality of style guides in the API registry as well as the generation of conformance reports. The test description teaches how to upload the style guide to the registry, upload the manifest to the registry, compute the conformance report, and view the conformance report.
 
 ## Test
 

--- a/lint/spectral-sample-styleguide/README.md
+++ b/lint/spectral-sample-styleguide/README.md
@@ -1,0 +1,27 @@
+## Summary
+
+The following repo contains a sample Spectral style guide that governs violations on OpenAPI Specs, along witha sample OpenAPI spec which violates multiple rules. This example is used to illustrate the functionality of style guides in the API registry as well as the generation of conformance reports. The test-description of this project teaches how to upload the style guide to the registry, upload the manifest to the registry, compute the conformance report, and the conformance report.
+
+## Test
+
+- Have registry running on `localhost:8080`.
+- Ensure that both `petstore.yaml` and `styleguide.yaml` from this directory are located in `~`.
+- Compile the registry project by running `make` in the root directory
+
+```bash
+apg registry delete-project --name projects/example
+
+apg registry create-project --project_id example --insecure --address localhost:8080
+
+apg registry create-api --api_id petstore --parent=projects/example/locations/global
+
+apg registry create-api-version --api_version_id v1 --parent=projects/example/locations/global/apis/petstore
+
+registry upload spec --version=projects/example/locations/global/apis/petstore/versions/v1 --style=openapi ~/petstore.yaml
+
+registry upload styleguide ~/styleguide.yaml --project-id=example
+
+registry compute conformance projects/example/locations/global/apis/petstore/versions/v1/specs/petstore.yaml --plugin=true
+
+registry get projects/example/locations/global/apis/petstore/versions/v1/specs/petstore.yaml/artifacts/conformance-apilinterstyleguide --contents
+```

--- a/lint/spectral-sample-styleguide/README.md
+++ b/lint/spectral-sample-styleguide/README.md
@@ -1,6 +1,6 @@
 ## Summary
 
-The following repo contains a sample Spectral style guide that governs violations on OpenAPI Specs, along witha sample OpenAPI spec which violates multiple rules. This example is used to illustrate the functionality of style guides in the API registry as well as the generation of conformance reports. The test-description of this project teaches how to upload the style guide to the registry, upload the manifest to the registry, compute the conformance report, and the conformance report.
+The following directory contains a sample Spectral style guide that governs violations on OpenAPI Specs, along witha sample OpenAPI spec which violates multiple rules. This example is used to illustrate the functionality of style guides in the API registry as well as the generation of conformance reports. The test-description of this project teaches how to upload the style guide to the registry, upload the manifest to the registry, compute the conformance report, and the conformance report.
 
 ## Test
 

--- a/lint/spectral-sample-styleguide/petstore.yaml
+++ b/lint/spectral-sample-styleguide/petstore.yaml
@@ -1,0 +1,202 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+openapi: "3.0.2"
+info:
+  title: "Swagger Petstore <script></script> with eval("
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pets:
+    get:
+      description: Gets a list of all pets
+      summary: List all pets
+      operationId: list pets
+      tags:
+        - pets
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "200":
+          description: A paged array of pets
+          headers:
+            x-next:
+              description: A link to the next page of responses
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pets"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    post:
+      description: Creates a new pet
+      summary: Create a pet
+      operationId: createPets
+      tags:
+        - pets
+      responses:
+        "401":
+          description: Null response
+    patch:
+      operationId: "update-pet"
+      responses:
+        "200":
+          description: ok
+    put:
+      operationId: "update-pet"
+      responses:
+        "200":
+          description: ok
+  /pets/{petId}:
+    get:
+      description: Gets the information for a pet
+      summary: Info for a specific pet
+      operationId: showPetById
+      tags:
+        - pets
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          schema:
+            type: string
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pet"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /pets/{}/:
+    get:
+      summary: Info for a specific pet
+      tags:
+        - pets
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pet"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /pets/getPetId/{petId}:
+    get:
+      summary: Info for a specific pet
+      tags:
+        - pets
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pet"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        tag:
+          type: string
+    Pets:
+      type: array
+      items:
+        $ref: "#/components/schemas/Pet"
+    Error:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string
+BadModel:
+  $ref: "#/components/TheBadModelProperties"
+  examples: # <= This property will be ignored
+    an_example:
+      name: something
+  properties:
+    number_of_connectors:
+      type: integer
+      description: The number of extension points.
+      enum:
+        - 1
+        - 2
+        - 2
+        - "string"
+        - 8

--- a/lint/spectral-sample-styleguide/styleguide.yaml
+++ b/lint/spectral-sample-styleguide/styleguide.yaml
@@ -1,0 +1,237 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+id: apilinterstyleguide
+mime_types:
+  - application/x.protobuf+zip
+guidelines:
+  - id: Operation
+    display_name: Govern properties of Operations
+    rules:
+      - id: OperationIdValidInURL
+        description: >
+          Seeing as operationId is often used for unique URLs in
+          documentation systems, it's a good idea to avoid non-URL
+          safe characters."
+        linter: spectral
+        linter_rulename: operation-operationId-valid-in-url
+        severity: WARNING
+        doc_uri: https://meta.stoplight.io/docs/spectral/ZG9jOjExNw-open-api-rules#operation-operationid-valid-in-url
+
+      - id: OperationTagsDefined
+        description: Operation tags should be defined in global tags.
+        linter: spectral
+        linter_rulename: operation-tag-defined
+        severity: WARNING
+        doc_uri: https://meta.stoplight.io/docs/spectral/ZG9jOjExNw-open-api-rules#operation-tag-defined
+
+      - id: OperationSuccessResponse
+        description: >
+          Operation must have at least one 2xx or 3xx response. 
+          Any API operation (endpoint) can fail, but presumably 
+          it is also meant to do something constructive at some point. 
+          If you forget to write out a success case for this API, 
+          then this rule will let you know.
+        linter: spectral
+        linter_rulename: operation-success-response
+        severity: WARNING
+        doc_uri: https://meta.stoplight.io/docs/spectral/ZG9jOjExNw-open-api-rules#operation-success-response
+
+      - id: OperationDescriptionPresent
+        description: Operation "description" must be present and non-empty string.
+        linter: spectral
+        linter_rulename: operation-operationId-valid-in-url
+        severity: WARNING
+        doc_uri: https://meta.stoplight.io/docs/spectral/ZG9jOjExNw-open-api-rules#operation-description
+
+      - id: OperationNonEmptyTags
+        description: Operation should have non-empty tags array.
+        linter: spectral
+        linter_rulename: operation-tags
+        severity: WARNING
+        doc_uri: https://meta.stoplight.io/docs/spectral/ZG9jOjExNw-open-api-rules#operation-tags
+
+      - id: OperationIdUnique
+        description: Every operation must have a unique operationId.
+        linter: spectral
+        linter_rulename: operation-operationId-unique
+        severity: ERROR
+        doc_uri: https://meta.stoplight.io/docs/spectral/ZG9jOjExNw-open-api-rules#operation-operationid-unique
+
+      - id: OperationId
+        description: Operation must have "operationId"."
+        linter: spectral
+        linter_rulename: operation-operationId
+        severity: WARNING
+        doc_uri: https://meta.stoplight.io/docs/spectral/ZG9jOjExNw-open-api-rules#operation-operationid
+
+      - id: OperationParameters
+        description: >
+          Operation parameters are unique and non-repeating.
+          1. Operations must have unique name + in parameters.
+          2. Operation cannot have both in: body and in: formData parameters. (OpenAPI v2.0)
+          3. Operation must have only one in: body parameter. (OpenAPI v2.0)
+        linter: spectral
+        linter_rulename: operation-parameters
+        severity: WARNING
+        doc_uri: https://meta.stoplight.io/docs/spectral/ZG9jOjExNw-open-api-rules#operation-parameters
+
+      - id: OperationIdValidInURL
+        description: >
+          Seeing as operationId is often used for unique URLs in
+          documentation systems, it's a good idea to avoid non-URL
+          safe characters."
+        linter: spectral
+        linter_rulename: operation-operationId-valid-in-url
+        severity: WARNING
+        doc_uri: https://meta.stoplight.io/docs/spectral/ZG9jOjExNw-open-api-rules#operation-operationid-valid-in-url
+
+      - id: OperationIdValidInURL
+        description: >
+          Seeing as operationId is often used for unique URLs in
+          documentation systems, it's a good idea to avoid non-URL
+          safe characters."
+        linter: spectral
+        linter_rulename: operation-operationId-valid-in-url
+        severity: WARNING
+        doc_uri: https://meta.stoplight.io/docs/spectral/ZG9jOjExNw-open-api-rules#operation-operationid-valid-in-url
+
+      - id: OperationIdValidInURL
+        description: >
+          Seeing as operationId is often used for unique URLs in
+          documentation systems, it's a good idea to avoid non-URL
+          safe characters."
+        linter: spectral
+        linter_rulename: operation-operationId-valid-in-url
+        severity: WARNING
+        doc_uri: https://meta.stoplight.io/docs/spectral/ZG9jOjExNw-open-api-rules#operation-operationid-valid-in-url
+
+      - id: OperationIdValidInURL
+        description: >
+          Seeing as operationId is often used for unique URLs in
+          documentation systems, it's a good idea to avoid non-URL
+          safe characters."
+        linter: spectral
+        linter_rulename: operation-operationId-valid-in-url
+        severity: WARNING
+        doc_uri: https://meta.stoplight.io/docs/spectral/ZG9jOjExNw-open-api-rules#operation-operationid-valid-in-url
+    status: ACTIVE
+
+  - id: Info
+    display_name: Govern properties of Info
+    rules:
+      - id: InfoContactRequired
+        description: >
+          Info object must have "contact" object.
+          Hopefully your API description document is so good that nobody ever
+          needs to contact you with questions, but that is rarely the case.
+          The contact object has a few different options for contact details.
+        linter: spectral
+        linter_rulename: info-contact
+        severity: ERROR
+        doc_uri: https://meta.stoplight.io/docs/spectral/ZG9jOjExNw-open-api-rules#info-contact
+
+      - id: InfoDescriptionRequired
+        description: >
+          OpenAPI object info description must be present and non-empty string.
+          Examples can contain Markdown so you can really go to town with them,
+          implementing getting started information like where to find authentication
+          keys, and how to use them.
+        linter: spectral
+        linter_rulename: info-description
+        severity: ERROR
+        doc_uri: https://meta.stoplight.io/docs/spectral/ZG9jOjExNw-open-api-rules#info-description
+
+      - id: InfoLicenseRecommended
+        description: >
+          The info object should have a license key.
+          It can be hard to pick a license, so if you don't have a lawyer around
+          you can use TLDRLegal and Choose a License to help give you an idea.
+          How useful this is in court is not entirely known, but having a license
+          is better than not having a license.
+        linter: spectral
+        linter_rulename: info-license
+        severity: WARNING
+        doc_uri: https://meta.stoplight.io/docs/spectral/ZG9jOjExNw-open-api-rules#info-license
+    status: ACTIVE
+
+  - id: Markdown
+    display_name: Govern properties of Markdown
+    rules:
+      - id: NoEvalInMarkdown
+        description: >
+          Markdown descriptions must not have "eval(". 
+          This rule protects against an edge case, for anyone bringing in description
+          documents from third parties and using the parsed content rendered in HTML/JS.
+          If one of those third parties does something shady like inject eval() JavaScript
+          statements, it could lead to an XSS attack.
+        linter: spectral
+        linter_rulename: no-eval-in-markdown
+        severity: ERROR
+        doc_uri: https://meta.stoplight.io/docs/spectral/ZG9jOjExNw-open-api-rules#no-eval-in-markdown
+
+      - id: NoScripTagsInMarkdown
+        description: >
+          Markdown descriptions must not have "<script>" tags.
+          This rule protects against a potential hack, for anyone bringing in description
+          documents from third parties then generating HTML documentation. If one of those
+          third parties does something shady like inject <script> tags, they could easily
+          execute arbitrary code on your domain, which if it's the same as your main
+          application could be all sorts of terrible.
+        linter: spectral
+        linter_rulename: no-script-tags-in-markdown
+        severity: ERROR
+        doc_uri: https://meta.stoplight.io/docs/spectral/ZG9jOjExNw-open-api-rules#no-script-tags-in-markdown
+
+    status: ACTIVE
+
+  - id: Path
+    display_name: Govern properties of Paths
+    rules:
+      - id: PathParams
+        description: >
+          Path parameters are correct and valid.
+          1. For every parameters referenced in the path string (i.e: /users/{userId}),
+             the parameter must be defined in either path.parameters, or operation.parameters objects
+             (Non standard HTTP operations will be silently ignored.)
+          2. every path.parameters and operation.parameters parameter must be used in the path string.
+        linter: spectral
+        linter_rulename: path-params
+        severity: ERROR
+        doc_uri: https://meta.stoplight.io/docs/spectral/ZG9jOjExNw-open-api-rules#path-params
+
+      - id: PathKeysNoTrailingSlash
+        description: >
+          Keep trailing slashes off of paths, as it can cause some confusion. Some web
+          tooling (like mock servers, real servers, code generators, application frameworks, etc.)
+          will treat example.com/foo and example.com/foo/ as the same thing, but other
+          tooling will not. Avoid any confusion by just documenting them without the slash,
+          and maybe some tooling will let people shove a / on there when they're using it
+          or maybe not, but at least the docs are suggesting how it should be done properly.
+        linter: spectral
+        linter_rulename: path-keys-no-trailing-slash
+        severity: WARNING
+        doc_uri: https://meta.stoplight.io/docs/spectral/ZG9jOjExNw-open-api-rules#path-keys-no-trailing-slash
+
+      - id: PathKeysNoTrailingSlash
+        description: Path parameter declarations cannot be empty, ex./given/{} is invalid.
+        linter: spectral
+        linter_rulename: path-declarations-must-exist
+        severity: WARNING
+        doc_uri: https://meta.stoplight.io/docs/spectral/ZG9jOjExNw-open-api-rules#path-declarations-must-exist
+
+    status: ACTIVE
+linters:
+  - name: spectral
+    uri: https://github.com/stoplightio/spectral


### PR DESCRIPTION
# Summary
The following pull request contains a sample Spectral style guide that governs violations on OpenAPI Specs, along witha sample OpenAPI spec which violates multiple rules. This example is used to illustrate the functionality of style guides in the API registry as well as the generation of conformance reports. The test description of the `README` file within this pull request teaches how to upload the style guide to the registry, upload the manifest to the registry, compute the conformance report, and view the conformance report.
