### PR TITLE
Added the Kubenetes configuration files for setting up Registry Server and Viewer on GKE

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,39 +23,43 @@ provides a read-only GraphQL interface to the Registry API. It can be run with
 a local or remote `registry-server`.
 
 ### Running the registry-server and viewer using docker
-We publish the Registry Server, Registry Viewer and Registry Envoy proxy docker 
-images to GitHub Packages. We have published a sample 
-[docker-compose.yml](docker-compose.yml) file to make is easier to set this up 
+
+We publish the Registry Server, Registry Viewer and Registry Envoy proxy docker
+images to GitHub Packages. We have published a sample
+[docker-compose.yml](docker-compose.yml) file to make is easier to set this up
 on your local environment.
 
 Steps to run this setup:
-1. Create a Google oAuth Client ID.
-   
-   Use the following values for the [form](https://console.cloud.google.com/apis/credentials/oauthclient):
-    - **Select the correct GCP Project.**
-    - Application Type : Web Application
-    - Name : API Registry 
-    - Javascript Authorized origins : http://localhost:8888
-    - Authorized redirect URIs: http://localhost:8888
 
-2. Update the `GOOGLE_SIGNIN_CLIENTID` value, in  `docker-compose.yml` file,
-    with the client ID from previous step.
+1. Create a Google oAuth Client ID.
+
+   Use the following values for the
+   [form](https://console.cloud.google.com/apis/credentials/oauthclient):
+
+   - **Select the correct GCP Project.**
+   - Application Type : Web Application
+   - Name : API Registry
+   - Javascript Authorized origins : http://localhost:8888
+   - Authorized redirect URIs: http://localhost:8888
+
+2. Update the `GOOGLE_SIGNIN_CLIENTID` value, in `docker-compose.yml` file,
+   with the client ID from previous step.
 
 3. Run the `docker compose up` command to start the server
 
 4. Setup environment variables to use registry tools
-    ```shell
-        export APG_REGISTRY_ADDRESS="localhost:9999"
-        export APG_ADMIN_ADDRESS=$APG_REGISTRY_ADDRESS
-        export APG_ADMIN_INSECURE=1
-        export APG_REGISTRY_INSECURE=1
-    ```
+   ```shell
+       export APG_REGISTRY_ADDRESS="localhost:9999"
+       export APG_ADMIN_ADDRESS=$APG_REGISTRY_ADDRESS
+       export APG_ADMIN_INSECURE=1
+       export APG_REGISTRY_INSECURE=1
+   ```
 5. Sample commands to create a project and api.
-    ```shell
-        apg admin create-project --project_id=project1
-        apg registry create-api --api_id=api1 --parent=projects/project1/locations/global
-        apg registry list-apis --parent=projects/project1/locations/global --json
-    ```
+   ```shell
+       apg admin create-project --project_id=project1
+       apg registry create-api --api_id=api1 --parent=projects/project1/locations/global
+       apg registry list-apis --parent=projects/project1/locations/global --json
+   ```
 6. To wipe out the local setup run `docker compose down -v`
 
 ## License

--- a/README.md
+++ b/README.md
@@ -22,6 +22,42 @@ registry tool.
 provides a read-only GraphQL interface to the Registry API. It can be run with
 a local or remote `registry-server`.
 
+### Running the registry-server and viewer using docker
+We publish the Registry Server, Registry Viewer and Registry Envoy proxy docker 
+images to GitHub Packages. We have published a sample 
+[docker-compose.yml](docker-compose.yml) file to make is easier to set this up 
+on your local environment.
+
+Steps to run this setup:
+1. Create a Google oAuth Client ID.
+   
+   Use the following values for the [form](https://console.cloud.google.com/apis/credentials/oauthclient):
+    - **Select the correct GCP Project.**
+    - Application Type : Web Application
+    - Name : API Registry 
+    - Javascript Authorized origins : http://localhost:8888
+    - Authorized redirect URIs: http://localhost:8888
+2. Update the `docker-compose.yml` file.
+   
+   Update the `GOOGLE_SIGNIN_CLIENTID` value with the client ID from previous 
+   step.
+3. Run the `docker compose up` command to start the server
+
+4. Setup environment variables to use registry tools
+    ```shell
+        export APG_REGISTRY_ADDRESS="localhost:9999"
+        export APG_ADMIN_ADDRESS=$APG_REGISTRY_ADDRESS
+        export APG_ADMIN_INSECURE=1
+        export APG_REGISTRY_INSECURE=1
+    ```
+5. Sample commands to create a project and api.
+    ```shell
+        apg admin create-project --project_id=project1
+        apg registry create-api --api_id=api1 --parent=projects/project1/locations/global
+        apg registry list-apis --parent=projects/project1/locations/global --json
+    ```
+6. To wipe out the local setup run `docker compose down -v`
+
 ## License
 
 This software is licensed under the Apache License, Version 2.0. See

--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ Steps to run this setup:
     - Name : API Registry 
     - Javascript Authorized origins : http://localhost:8888
     - Authorized redirect URIs: http://localhost:8888
-2. Update the `docker-compose.yml` file.
-   
-   Update the `GOOGLE_SIGNIN_CLIENTID` value with the client ID from previous 
-   step.
+
+2. Update the `GOOGLE_SIGNIN_CLIENTID` value, in  `docker-compose.yml` file,
+    with the client ID from previous step.
+
 3. Run the `docker compose up` command to start the server
 
 4. Setup environment variables to use registry tools

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,67 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: '3'
+services:
+  registry-database:
+    image: postgres:latest
+    volumes:
+    - registry-db-vol:/var/lib/postgresql/data/pgdata
+    environment:
+    - PGDATA=/var/lib/postgresql/data/pgdata
+    - POSTGRES_DB=apigee_registry
+    - POSTGRES_USER=dbuser
+    - POSTGRES_PASSWORD=passw0rd
+  registry-server:
+    image: ghcr.io/apigee/registry-server:main
+    ports:
+    - "8080:8080"
+    environment:
+    - REGISTRY_DATABASE_DRIVER=postgres
+    - REGISTRY_DATABASE_CONFIG="host=registry-database port=5432 user=dbuser dbname=apigee_registry password=passw0rd sslmode=disable"
+    - REGISTRY_LOGGING_LEVEL=debug
+    - REGISTRY_LOGGING_FORMAT=text
+    - REGISTRY_PUBSUB_ENABLE=false
+    - REGISTRY_PUBSUB_PROJECT=
+    - PORT=8080
+    links:
+    - registry-database
+    depends_on:
+    - registry-database
+  envoy-registry:
+    image: ghcr.io/apigee/registry-envoy:main
+    environment:
+    - REGISTRY_SERVER_HOST=registry-server
+    - REGISTRY_SERVER_PORT=8080
+    ports:
+    - "9999:9999"
+    - "9901:9901"
+    links:
+    - registry-server
+    depends_on:
+    - registry-server
+  registry-app:
+    image: ghcr.io/apigee/registry-app:main
+    environment:
+    - GOOGLE_SIGNIN_CLIENTID=testClientId
+    - REGISTRY_SERVICE=http://localhost:9999
+    - PORT=8888
+    ports:
+    - "8888:8888"
+    links:
+    - registry-server
+    depends_on:
+    - registry-server
+volumes:
+  registry-db-vol:

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -8,11 +8,11 @@ with Cloud SQL for PostgreSQL.
 
 Steps to install Apigee Registry & Viewer in your GKE Cluster:
 1. Copy the sample folder and create a new folder
-    ```
+    ```shell
         cp -rf kubenetes/sample kubenetes/registry-demo
     ```
 2. We need a static IP for this demo: 
-    ```
+    ```shell
         gcloud compute addresses create registry-app-static-ip \
         --global \
         --ip-version IPV4 
@@ -50,12 +50,12 @@ Steps to install Apigee Registry & Viewer in your GKE Cluster:
     Replace the `GOOGLE_SIGNIN_CLIENTID` in kubernetes/registry-demo/patch.yaml with the Client ID that was generated.
 
 6. Ensure you are connected to the correct GKE cluster :
-    ```
+    ```shell
         gcloud container clusters get-credentials **cluster-name** --region **region** \
         --project **GCP-Project**
     ```
 7. Run the following command to create the deployment setup:
-    ```
+    ```shell
         kubectl create ns api-registry
         
         kubectl apply -k kubernetes/registry-demo
@@ -64,7 +64,7 @@ Steps to install Apigee Registry & Viewer in your GKE Cluster:
 8. The solution should be ready in about 10-15 minutes. 
    Check the status of the following:
    - Check the status of certs using :
-     ```
+     ```shell
         gcloud compute ssl-certificates list --global
      ```
    - Deploy the ingress rules
@@ -72,11 +72,11 @@ Steps to install Apigee Registry & Viewer in your GKE Cluster:
 
 9. Application is ready when the following curl command returns 200.
    If using sslip.io domain:
-   ```
+   ```shell
         curl -I https://1-2-3-4.sslip.io 
     ```
     If using custom-domain
-   ```
+   ```shell
         curl -I https://registry-app.example.com
     ```
 
@@ -84,7 +84,7 @@ Steps to install Apigee Registry & Viewer in your GKE Cluster:
    or your custom domain
    
 11. To use the registry tools run the following commands: 
-    ```
+    ```shell
         export APG_REGISTRY_ADDRESS=$(kubectl get svc -n api-registry registry-server-external-lb  -o jsonpath="{.status.loadBalancer.ingress[0].ip}:{.spec.ports[0].port}")
         export APG_ADMIN_ADDRESS=$APG_REGISTRY_ADDRESS
         export APG_ADMIN_INSECURE=1
@@ -92,8 +92,15 @@ Steps to install Apigee Registry & Viewer in your GKE Cluster:
     ```
 
 12. Now you can interact with the registry tools using
-    ```
+    ```shell
         apg admin create-project --project_id=project1
         apg registry create-api --api_id=api1 --parent=projects/project1/locations/global
         apg registry list-apis --parent=projects/project1/locations/global --json
+    ```
+
+13. Run the following command to wipe out this setup
+    ```shell
+        kubectl delete -k kubernetes/registry-demo
+        kubectl delete ns api-registry
+        gcloud compute addresses delete registry-app-static-ip --global --quiet
     ```

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -3,66 +3,74 @@
 The kubernetes directory has all the configuration to setup a registry server
 and registry viewer in you Kubernetes cluster.
 
-This deployment runs a pod with postgres database. It can be easily replaced 
+This deployment runs a pod with postgres database. It can be easily replaced
 with Cloud SQL for PostgreSQL.
 
 Steps to install Apigee Registry & Viewer in your GKE Cluster:
+
 1. Copy the sample folder and create a new folder
-    ```shell
-        cp -rf kubenetes/sample kubenetes/registry-demo
-    ```
-2. We need a static IP for this demo: 
-    ```shell
-        gcloud compute addresses create registry-app-static-ip \
-        --global \
-        --ip-version IPV4 
+   ```shell
+       cp -rf kubenetes/sample kubenetes/registry-demo
+   ```
+2. We need a static IP for this demo:
+
+   ```shell
+       gcloud compute addresses create registry-app-static-ip \
+       --global \
+       --ip-version IPV4
    ```
 
    Please note down the above IP addresses.
 
 3. You may choose to use your own DNS entry or use the wildcard sslip.io domain
-    > This is required so that we can generate Google Managed SSL Certs.
-    > 
-    > e.g. if "registry-app-static-ip" is 1.2.3.4 you can use 1-2-3-4.sslip.io
 
-    > If you are using your own DNS entries create an A record :    
-      registry-demo.example.com  points to 1.2.3.4
+   > This is required so that we can generate Google Managed SSL Certs.
+   >
+   > e.g. if "registry-app-static-ip" is 1.2.3.4 you can use 1-2-3-4.sslip.io
 
-   
-   Replace the 1 occurrence of `registry-app.example.com` in kubernetes/registry-demo/patch.yaml with `1-2-3-4.sslip.io`
-   or the custom domain you reserved for setting this demo
+   > If you are using your own DNS entries create an A record :  
+   >  registry-demo.example.com points to 1.2.3.4
 
-4. If you choose to use Cloud SQL with PostgreSQL you can modify the 
-   `REGISTRY_DATABASE_CONFIG` entry and replace the string with the details
-   You will have to additionally delete the registry-database pods once the setup is complete.
+   Replace the 1 occurrence of `registry-app.example.com` in
+   kubernetes/registry-demo/patch.yaml with `1-2-3-4.sslip.io` or the custom
+   domain you reserved for setting this demo
 
-5. Create a Google oAuth Client ID are [here](https://console.cloud.google.com/apis/credentials/oauthclient)
-   
-    **Select the correct GCP Project.**
-    Use the following values for the form:   
-    - Application Type : Web Application
-    - Name : API Registry Viewer
-    - Javascript Authorized origins : Custom domain of the registry viewer 
-        (e.g. https://1-2-3-4.sslip.io or https://registry-app.example.com)
-    - Authorized redirect URIs: Custom domain of the registry viewer 
-        (e.g. https://1-2-3-4.sslip.io or https://registry-app.example.com)
+4. If you choose to use Cloud SQL with PostgreSQL you can modify the
+   `REGISTRY_DATABASE_CONFIG` entry and replace the string with the details You
+   will have to additionally delete the registry-database pods once the setup
+   is complete.
 
-    Replace the `GOOGLE_SIGNIN_CLIENTID` in kubernetes/registry-demo/patch.yaml with the Client ID that was generated.
+5. Create a Google oAuth Client ID are
+   [here](https://console.cloud.google.com/apis/credentials/oauthclient)
+
+   **Select the correct GCP Project.** Use the following values for the form:
+
+   - Application Type : Web Application
+   - Name : API Registry Viewer
+   - Javascript Authorized origins : Custom domain of the registry viewer (e.g.
+     https://1-2-3-4.sslip.io or https://registry-app.example.com)
+   - Authorized redirect URIs: Custom domain of the registry viewer (e.g.
+     https://1-2-3-4.sslip.io or https://registry-app.example.com)
+
+   Replace the `GOOGLE_SIGNIN_CLIENTID` in kubernetes/registry-demo/patch.yaml
+   with the Client ID that was generated.
 
 6. Ensure you are connected to the correct GKE cluster :
-    ```shell
-        gcloud container clusters get-credentials **cluster-name** --region **region** \
-        --project **GCP-Project**
-    ```
+   ```shell
+       gcloud container clusters get-credentials **cluster-name** --region **region** \
+       --project **GCP-Project**
+   ```
 7. Run the following command to create the deployment setup:
-    ```shell
-        kubectl create ns api-registry
-        
-        kubectl apply -k kubernetes/registry-demo
-    ```
 
-8. The solution should be ready in about 10-15 minutes. 
-   Check the status of the following:
+   ```shell
+       kubectl create ns api-registry
+
+       kubectl apply -k kubernetes/registry-demo
+   ```
+
+8. The solution should be ready in about 10-15 minutes. Check the status of the
+   following:
+
    - Check the status of certs using :
      ```shell
         gcloud compute ssl-certificates list --global
@@ -70,20 +78,24 @@ Steps to install Apigee Registry & Viewer in your GKE Cluster:
    - Deploy the ingress rules
    - Health checks to pass
 
-9. Application is ready when the following curl command returns 200.
-   If using sslip.io domain:
+9. Application is ready when the following curl command returns 200. If using
+   sslip.io domain:
+
    ```shell
-        curl -I https://1-2-3-4.sslip.io 
-    ```
-    If using custom-domain
+        curl -I https://1-2-3-4.sslip.io
+   ```
+
+   If using custom-domain
+
    ```shell
         curl -I https://registry-app.example.com
-    ```
+   ```
 
-10. You should be able to access the viewer using https://1-2-3-4.sslip.io 
-   or your custom domain
-   
-11. To use the registry tools run the following commands: 
+10. You should be able to access the viewer using https://1-2-3-4.sslip.io or
+    your custom domain
+
+11. To use the registry tools run the following commands:
+
     ```shell
         export APG_REGISTRY_ADDRESS=$(kubectl get svc -n api-registry registry-server-external-lb  -o jsonpath="{.status.loadBalancer.ingress[0].ip}:{.spec.ports[0].port}")
         export APG_ADMIN_ADDRESS=$APG_REGISTRY_ADDRESS
@@ -92,6 +104,7 @@ Steps to install Apigee Registry & Viewer in your GKE Cluster:
     ```
 
 12. Now you can interact with the registry tools using
+
     ```shell
         apg admin create-project --project_id=project1
         apg registry create-api --api_id=api1 --parent=projects/project1/locations/global

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -8,13 +8,14 @@ with Cloud SQL for PostgreSQL.
 
 Steps to install Apigee Registry & Viewer in your GKE Cluster:
 1. Copy the sample folder and create a new folder
-   > cp -rf kubenetes/sample kubenetes/registry-demo
-
+    ```
+        cp -rf kubenetes/sample kubenetes/registry-demo
+    ```
 2. We need a static IP for this demo: 
     ```
-       gcloud compute addresses create registry-app-static-ip \
-       --global \
-       --ip-version IPV4 
+        gcloud compute addresses create registry-app-static-ip \
+        --global \
+        --ip-version IPV4 
    ```
 
    Please note down the above IP addresses.
@@ -48,19 +49,19 @@ Steps to install Apigee Registry & Viewer in your GKE Cluster:
 
     Replace the `GOOGLE_SIGNIN_CLIENTID` in kubernetes/registry-demo/patch.yaml with the Client ID that was generated.
 
-5. Ensure you are connected to the correct GKE cluster :
+6. Ensure you are connected to the correct GKE cluster :
     ```
-      gcloud container clusters get-credentials **cluster-name** --region **region** \
-       --project **GCP-Project**
+        gcloud container clusters get-credentials **cluster-name** --region **region** \
+        --project **GCP-Project**
     ```
-6. Run the following command to create the deployment setup:
+7. Run the following command to create the deployment setup:
     ```
-      kubectl create ns api-registry
+        kubectl create ns api-registry
+        
+        kubectl apply -k kubernetes/registry-demo
+    ```
 
-      kubectl apply -k kubernetes/registry-demo
-    ```
-
-7. The solution should be ready in about 10-15 minutes. 
+8. The solution should be ready in about 10-15 minutes. 
    Check the status of the following:
    - Check the status of certs using :
      ```
@@ -69,20 +70,30 @@ Steps to install Apigee Registry & Viewer in your GKE Cluster:
    - Deploy the ingress rules
    - Health checks to pass
 
-8. You should be able to access the viewer using https://1-2-3-4.sslip.io 
-   or your custom domain
-   
-9. Get the IP address for the registry GRPC service using the following command:
+9. Application is ready when the following curl command returns 200.
+   If using sslip.io domain:
+   ```
+        curl -I https://1-2-3-4.sslip.io 
     ```
-   export APG_REGISTRY_ADDRESS=$(kubectl get svc -n api-registry registry-server-external-lb  -o jsonpath="{.status.loadBalancer.ingress[0].ip}:{.spec.ports[0].port}")
-   export APG_ADMIN_ADDRESS=$APG_REGISTRY_ADDRESS
-   export APG_ADMIN_INSECURE=1
-   export APG_REGISTRY_INSECURE=1
+    If using custom-domain
+   ```
+        curl -I https://registry-app.example.com
     ```
 
-10. Now you can interact with the registry tools using
+10. You should be able to access the viewer using https://1-2-3-4.sslip.io 
+   or your custom domain
+   
+11. To use the registry tools run the following commands: 
     ```
-    apg admin create-project --project_id=project1
-    apg registry create-api --api_id=api1 --parent=projects/project1/locations/global
-    apg registry list-apis --parent=projects/project1/locations/global --json
+        export APG_REGISTRY_ADDRESS=$(kubectl get svc -n api-registry registry-server-external-lb  -o jsonpath="{.status.loadBalancer.ingress[0].ip}:{.spec.ports[0].port}")
+        export APG_ADMIN_ADDRESS=$APG_REGISTRY_ADDRESS
+        export APG_ADMIN_INSECURE=1
+        export APG_REGISTRY_INSECURE=1
+    ```
+
+12. Now you can interact with the registry tools using
+    ```
+        apg admin create-project --project_id=project1
+        apg registry create-api --api_id=api1 --parent=projects/project1/locations/global
+        apg registry list-apis --parent=projects/project1/locations/global --json
     ```

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -1,0 +1,88 @@
+# Deploying Registry Server and Registry Viewer on GKE
+
+The kubernetes directory has all the configuration to setup a registry server
+and registry viewer in you Kubernetes cluster.
+
+This deployment runs a pod with postgres database. It can be easily replaced 
+with Cloud SQL for PostgreSQL.
+
+Steps to install Apigee Registry & Viewer in your GKE Cluster:
+1. Copy the sample folder and create a new folder
+   > cp -rf kubenetes/sample kubenetes/registry-demo
+
+2. We need a static IP for this demo: 
+    ```
+       gcloud compute addresses create registry-app-static-ip \
+       --global \
+       --ip-version IPV4 
+   ```
+
+   Please note down the above IP addresses.
+
+3. You may choose to use your own DNS entry or use the wildcard sslip.io domain
+    > This is required so that we can generate Google Managed SSL Certs.
+    > 
+    > e.g. if "registry-app-static-ip" is 1.2.3.4 you can use 1-2-3-4.sslip.io
+
+    > If you are using your own DNS entries create an A record :    
+      registry-demo.example.com  points to 1.2.3.4
+
+   
+   Replace the 1 occurrence of `registry-app.example.com` in kubernetes/registry-demo/patch.yaml with `1-2-3-4.sslip.io`
+   or the custom domain you reserved for setting this demo
+
+4. If you choose to use Cloud SQL with PostgreSQL you can modify the 
+   `REGISTRY_DATABASE_CONFIG` entry and replace the string with the details
+   You will have to additionally delete the registry-database pods once the setup is complete.
+
+5. Create a Google oAuth Client ID are [here](https://console.cloud.google.com/apis/credentials/oauthclient)
+   
+    **Select the correct GCP Project.**
+    Use the following values for the form:   
+    - Application Type : Web Application
+    - Name : API Registry Viewer
+    - Javascript Authorized origins : Custom domain of the registry viewer 
+        (e.g. https://1-2-3-4.sslip.io or https://registry-app.example.com)
+    - Authorized redirect URIs: Custom domain of the registry viewer 
+        (e.g. https://1-2-3-4.sslip.io or https://registry-app.example.com)
+
+    Replace the `GOOGLE_SIGNIN_CLIENTID` in kubernetes/registry-demo/patch.yaml with the Client ID that was generated.
+
+5. Ensure you are connected to the correct GKE cluster :
+    ```
+      gcloud container clusters get-credentials **cluster-name** --region **region** \
+       --project **GCP-Project**
+    ```
+6. Run the following command to create the deployment setup:
+    ```
+      kubectl create ns api-registry
+
+      kubectl apply -k kubernetes/registry-demo
+    ```
+
+7. The solution should be ready in about 10-15 minutes. 
+   Check the status of the following:
+   - Check the status of certs using :
+     ```
+        gcloud compute ssl-certificates list --global
+     ```
+   - Deploy the ingress rules
+   - Health checks to pass
+
+8. You should be able to access the viewer using https://1-2-3-4.sslip.io 
+   or your custom domain
+   
+9. Get the IP address for the registry GRPC service using the following command:
+    ```
+   export APG_REGISTRY_ADDRESS=$(kubectl get svc -n api-registry registry-server-external-lb  -o jsonpath="{.status.loadBalancer.ingress[0].ip}:{.spec.ports[0].port}")
+   export APG_ADMIN_ADDRESS=$APG_REGISTRY_ADDRESS
+   export APG_ADMIN_INSECURE=1
+   export APG_REGISTRY_INSECURE=1
+    ```
+
+10. Now you can interact with the registry tools using
+    ```
+    apg admin create-project --project_id=project1
+    apg registry create-api --api_id=api1 --parent=projects/project1/locations/global
+    apg registry list-apis --parent=projects/project1/locations/global --json
+    ```

--- a/kubernetes/base/00-registry-db.yaml
+++ b/kubernetes/base/00-registry-db.yaml
@@ -1,0 +1,94 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Deployment for the Postgres Database
+#
+# This can be replaced by CloudSQL for PostGreSQL
+#
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: registry-database-pvc
+  labels:
+    app: registry-database
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: registry-database
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: registry-database
+  template:
+    metadata:
+      labels:
+        app: registry-database
+    spec:
+      volumes:
+      - name: registry-database-vol
+        persistentVolumeClaim:
+          claimName: registry-database-pvc
+      containers:
+      - name: registry-database
+        image: postgres:latest
+        imagePullPolicy: Always
+        volumeMounts:
+        - mountPath: "/var/lib/postgresql/data"
+          name: registry-database-vol
+        env:
+        - name: PGDATA
+          value: "/var/lib/postgresql/data/pgdata"
+        - name: POSTGRES_DB
+          valueFrom:
+            configMapKeyRef:
+              name: registry-config
+              key: POSTGRES_DB
+        - name: POSTGRES_USER
+          valueFrom:
+            configMapKeyRef:
+              name: registry-config
+              key: POSTGRES_USER
+        - name: POSTGRES_PASSWORD
+          valueFrom:
+            configMapKeyRef:
+              name: registry-config
+              key: POSTGRES_PASSWORD
+        ports:
+        - containerPort: 5432
+          protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: registry-database-svc
+  labels:
+    app: registry-database
+spec:
+  type: ClusterIP
+  selector:
+    app: registry-database
+  ports:
+  - protocol: TCP
+    port: 5432
+    targetPort: 5432

--- a/kubernetes/base/01-registry-server.yaml
+++ b/kubernetes/base/01-registry-server.yaml
@@ -1,0 +1,68 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Deployment for the Registry Server
+#
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: registry-server
+spec:
+  selector:
+    matchLabels:
+      app: registry-server
+  template:
+    metadata:
+      labels:
+        app: registry-server
+    spec:
+      containers:
+      - name: registry-server
+        image: ghcr.io/apigee/registry-server:main
+        imagePullPolicy: Always
+        env:
+        - name: PORT
+          value: "8080"
+        - name: REGISTRY_DATABASE_DRIVER
+          value: "postgres"
+        - name: REGISTRY_LOGGING_LEVEL
+          value: "debug"
+        - name: REGISTRY_LOGGING_FORMAT
+          value: "text"
+        - name: REGISTRY_PUBSUB_ENABLE
+          value: "false"
+        - name: REGISTRY_DATABASE_CONFIG
+          valueFrom:
+            configMapKeyRef:
+              name: registry-config
+              key: REGISTRY_DATABASE_CONFIG
+        ports:
+        - containerPort: 8080
+          protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: registry-server-grpc
+spec:
+  type: ClusterIP
+  selector:
+    app: registry-server
+  ports:
+  - protocol: TCP
+    name: grpc-port
+    port: 8080
+    targetPort: 8080

--- a/kubernetes/base/02-registry-envoy.yaml
+++ b/kubernetes/base/02-registry-envoy.yaml
@@ -1,0 +1,116 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Deployment for Envoy proxy to use with the Registry Server
+#
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: registry-envoy
+spec:
+  selector:
+    matchLabels:
+      app: registry-envoy
+  template:
+    metadata:
+      labels:
+        app: registry-envoy
+    spec:
+      containers:
+      - name: envoy
+        image: ghcr.io/apigee/registry-envoy:main
+        imagePullPolicy: Always
+        env:
+        - name: REGISTRY_SERVER_HOST
+          value: "registry-server-grpc.api-registry.svc.cluster.local"
+        - name: REGISTRY_SERVER_PORT
+          value: "8080"
+        - name: PORT
+          value: "9999"
+        ports:
+        - name: admin-port
+          containerPort: 9901
+        - name: envoy-port
+          containerPort: 9999
+#        resources:
+#          requests:
+#            cpu: 10m
+#            ephemeral-storage: 256Mi
+#            memory: 256Mi
+        readinessProbe:
+          httpGet:
+            port: admin-port
+            path: /ready
+            scheme: HTTP
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          failureThreshold: 10
+        livenessProbe:
+          httpGet:
+            port: admin-port
+            path: /ready
+            scheme: HTTP
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          failureThreshold: 10
+---
+apiVersion: cloud.google.com/v1
+kind: BackendConfig
+metadata:
+  name: registry-server-envoy-backendconfig
+spec:
+  healthCheck:
+    checkIntervalSec: 10
+    timeoutSec: 5
+    healthyThreshold: 1
+    unhealthyThreshold: 10
+    type: HTTP
+    requestPath: /ready
+    port: 9901
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: registry-envoy-http-lb
+  annotations:
+    cloud.google.com/app-protocols: '{"envoy-port":"HTTP", "admin-port": "HTTP"}'
+    cloud.google.com/backend-config: '{"ports": {"9999":"registry-server-envoy-backendconfig"}}'
+spec:
+  type: NodePort
+  selector:
+    app: registry-envoy
+  ports:
+  - name: admin-port
+    protocol: TCP
+    port: 9901
+    targetPort: 9901
+  - name: envoy-port
+    protocol: TCP
+    port: 9999
+    targetPort: 9999
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: registry-server-external-lb
+spec:
+  type: LoadBalancer
+  selector:
+    app: registry-envoy
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 9999

--- a/kubernetes/base/03-registry-app.yaml
+++ b/kubernetes/base/03-registry-app.yaml
@@ -1,0 +1,70 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Deployment for the Registry Viewer
+#
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: registry-app
+spec:
+  selector:
+    matchLabels:
+      app: registry-app
+  template:
+    metadata:
+      labels:
+        app: registry-app
+    spec:
+      containers:
+      - name: registry-app
+        image: ghcr.io/apigee/registry-app:main
+        imagePullPolicy: Always
+        env:
+        - name: PORT
+          value: "8888"
+        - name: GOOGLE_SIGNIN_CLIENTID
+          valueFrom:
+            configMapKeyRef:
+              name: registry-config
+              key: GOOGLE_SIGNIN_CLIENTID
+        - name: REGISTRY_SERVICE
+          value: "/"
+        ports:
+        - name: app-port
+          containerPort: 8888
+        readinessProbe:
+          httpGet:
+            port: app-port
+            path: /
+            scheme: HTTP
+        livenessProbe:
+          httpGet:
+            port: app-port
+            path: /
+            scheme: HTTP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: registry-app-cluster-lb
+spec:
+  type: ClusterIP
+  selector:
+    app: registry-app
+  ports:
+  - protocol: TCP
+    port: 8888
+    targetPort: 8888

--- a/kubernetes/base/04-registry-ingress.yaml
+++ b/kubernetes/base/04-registry-ingress.yaml
@@ -1,0 +1,68 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# We deploy an ingress so we can assign static ip and
+# add a Google Managed Certificate for the Registry Viewer
+#
+
+apiVersion: networking.gke.io/v1
+kind: ManagedCertificate
+metadata:
+  name: registry-app-cert
+spec:
+  domains:
+  - registry-app.example.com
+---
+apiVersion: networking.gke.io/v1beta1
+kind: FrontendConfig
+metadata:
+  name: registry-app-frontend
+spec:
+  redirectToHttps:
+    enabled: true
+    responseCodeName: "301"
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: registry-app-ingress
+  annotations:
+    networking.gke.io/v1beta1.FrontendConfig: registry-app-frontend
+    kubernetes.io/ingress.global-static-ip-name: registry-app-static-ip
+    networking.gke.io/managed-certificates: registry-app-cert
+    kubernetes.io/ingress.class: "gce"
+spec:
+  defaultBackend:
+    service:
+      name:  registry-app-cluster-lb
+      port:
+        number: 8888
+  rules:
+  - http:
+      paths:
+      - pathType: ImplementationSpecific
+        path: "/google.cloud.apigeeregistry.v1.Admin/*"
+        backend:
+          service:
+            name: registry-envoy-http-lb
+            port:
+              number: 9999
+      - pathType: ImplementationSpecific
+        path: "/google.cloud.apigeeregistry.v1.Registry/*"
+        backend:
+          service:
+            name: registry-envoy-http-lb
+            port:
+              number: 9999

--- a/kubernetes/base/kustomization.yaml
+++ b/kubernetes/base/kustomization.yaml
@@ -1,0 +1,31 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resources:
+- 00-registry-db.yaml
+- 01-registry-server.yaml
+- 02-registry-envoy.yaml
+- 03-registry-app.yaml
+- 04-registry-ingress.yaml
+
+namespace: api-registry
+
+configMapGenerator:
+- name: registry-config
+  literals:
+  - POSTGRES_DB="apigee_registry"
+  - POSTGRES_USER="dbuser"
+  - POSTGRES_PASSWORD="passw0rd"
+  - REGISTRY_DATABASE_CONFIG="host=registry-database-svc.api-registry.svc.cluster.local port=5432 user=dbuser dbname=apigee_registry password=passw0rd sslmode=disable"
+  - GOOGLE_SIGNIN_CLIENTID="testvalue"

--- a/kubernetes/sample/kustomization.yaml
+++ b/kubernetes/sample/kustomization.yaml
@@ -1,0 +1,19 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+bases:
+- ../base
+
+patchesStrategicMerge:
+- patch.yaml

--- a/kubernetes/sample/patch.yaml
+++ b/kubernetes/sample/patch.yaml
@@ -1,0 +1,40 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# These values can be changed to follow your setup.
+#
+#
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: registry-config
+data:
+#If you change the POSTGRES_* values make changes accordingly to the REGISTY_DATABASE_CONFIG entry
+  POSTGRES_DB: "apigee_registry"
+  POSTGRES_USER: "dbuser"
+  POSTGRES_PASSWORD: "passw0rd"
+  REGISTRY_DATABASE_CONFIG: "host=registry-database-svc.api-registry.svc.cluster.local port=5432 user=dbuser dbname=apigee_registry password=passw0rd sslmode=disable"
+  GOOGLE_SIGNIN_CLIENTID: "CLIENT_ID"
+---
+apiVersion: networking.gke.io/v1
+kind: ManagedCertificate
+metadata:
+  name: registry-app-cert
+spec:
+  domains:
+# Replace the domain with your own custom domain or use the static IP address
+# with sslip.io domain (e.g. 1-2-3-4.sslip.io)
+  - registry-app.example.com


### PR DESCRIPTION
This configuration using the Envoy Adapter without Authentication. 

Next step is to move the envoy docker build files to registry-experimental. Since it does not need to be in registry server.