### PR TITLE
Prism controller to create Mock Server for OpenAPI specs in the Registry

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -23,7 +23,7 @@ on:
   schedule:
     - cron: '10 16 * * *'
   push:
-    branches: [ main ]
+    branches: [ main, api-mocker ]
     # Publish semver tags as releases.
     tags: [ 'v*.*.*' ]
   pull_request:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -23,7 +23,7 @@ on:
   schedule:
     - cron: '10 16 * * *'
   push:
-    branches: [ main ]
+    branches: [ main, api-mocker ]
     # Publish semver tags as releases.
     tags: [ 'v*.*.*' ]
   pull_request:
@@ -32,18 +32,27 @@ on:
 env:
   # Use docker.io for Docker Hub if empty
   REGISTRY: ghcr.io
-  # github.repository as <account>/<repo>
-  AUTHZ_SERVER: ${{github.repository_owner}}/registry-authz-server
-  SPEC_RENDERER: ${{github.repository_owner}}/registry-spec-renderer
-
 jobs:
-  build:
-
+  build_containers:
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
-
+    strategy:
+      matrix:
+        include:
+        -   image: ${{github.repository_owner}}/registry-authz-server
+            context: "."
+            dockerfile: "containers/registry-authz-server/Dockerfile"
+        -   image: ${{github.repository_owner}}/registry-spec-renderer
+            context: "containers/registry-spec-renderer"
+            dockerfile: "containers/registry-spec-renderer/Dockerfile"
+        -   image: ${{github.repository_owner}}/prism-registry-mock-server
+            context: "containers/prism-registry-mock-server"
+            dockerfile: containers/prism-registry-mock-server/Dockerfile
+        -   image: ${{github.repository_owner}}/registry-prism-mock-controller
+            context: "samples/registry-prism-mock-controller"
+            dockerfile: samples/registry-prism-mock-controller/Dockerfile
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -52,7 +61,7 @@ jobs:
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
+        uses: docker/login-action@v1
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -62,39 +71,19 @@ jobs:
       # https://github.com/docker/metadata-action
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        uses: docker/metadata-action@v3
         with:
-          images: ${{ env.REGISTRY }}/${{ env.AUTHZ_SERVER }}
+          images: ${{ env.REGISTRY }}/${{ matrix.image }}
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action
-      - name: Build and push registry-authz-server Docker image
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+      - name: Build and push ${{ env.REGISTRY }}/${{ matrix.image }} Docker image
+        uses: docker/build-push-action@v2
         with:
-          context: .
-          file: containers/registry-authz-server/Dockerfile
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-
-      # Extract metadata (tags, labels) for Docker
-      # https://github.com/docker/metadata-action
-      - name: Extract Docker metadata
-        id: meta_spec_renderer
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.SPEC_RENDERER }}
-
-      # Build and push Docker image with Buildx (don't push on PR)
-      # https://github.com/docker/build-push-action
-      - name: Build and push registry-spec-renderer Docker image
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
-        with:
-          context: containers/registry-spec-renderer
-          file: containers/registry-spec-renderer/Dockerfile
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta_spec_renderer.outputs.tags }}
-          labels: ${{ steps.meta_spec_renderer.outputs.labels }}
           build-args: |
             NPM_AUTH_TOKEN=${{ secrets.GITHUB_TOKEN }}
-

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -23,7 +23,7 @@ on:
   schedule:
     - cron: '10 16 * * *'
   push:
-    branches: [ main, api-mocker ]
+    branches: [ main ]
     # Publish semver tags as releases.
     tags: [ 'v*.*.*' ]
   pull_request:

--- a/containers/prism-registry-mock-server/Dockerfile
+++ b/containers/prism-registry-mock-server/Dockerfile
@@ -1,3 +1,17 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 FROM ghcr.io/apigee/registry-tools:latest as registry-tools
 ENV REGISTRY_SPEC=""
 ENV APG_REGISTRY_ADDRESS=apigeeregistry.googleapis.com:443

--- a/containers/prism-registry-mock-server/Dockerfile
+++ b/containers/prism-registry-mock-server/Dockerfile
@@ -1,0 +1,18 @@
+FROM ghcr.io/apigee/registry-tools:latest as registry-tools
+ENV REGISTRY_SPEC=""
+ENV APG_REGISTRY_ADDRESS=apigeeregistry.googleapis.com:443
+ENV APG_REGISTRY_INSECURE=0
+
+FROM launcher.gcr.io/google/nodejs
+ENV REGISTRY_SPEC=""
+ENV APG_REGISTRY_ADDRESS=apigeeregistry.googleapis.com:443
+ENV APG_REGISTRY_INSECURE=0
+
+EXPOSE 4010
+
+COPY --from=registry-tools /bin/registry /bin/registry
+COPY ./entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh && npm install -g @stoplight/prism-cli
+
+ENTRYPOINT ["/entrypoint.sh"]
+

--- a/containers/prism-registry-mock-server/README.md
+++ b/containers/prism-registry-mock-server/README.md
@@ -1,0 +1,4 @@
+# Prism Registry Mock Server
+
+Docker image which uses registry tool to read the spec from the registry server.
+It uses [Prism](https://stoplight.io/open-source/prism/) to create a mock server.

--- a/containers/prism-registry-mock-server/entrypoint.sh
+++ b/containers/prism-registry-mock-server/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+
+registry get $REGISTRY_SPEC --contents > /openapi.yaml
+
+prism mock -h "0.0.0.0" /openapi.yaml

--- a/containers/prism-registry-mock-server/entrypoint.sh
+++ b/containers/prism-registry-mock-server/entrypoint.sh
@@ -13,6 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+if [ "$APG_REGISTRY_ADDRESS" == 'apigeeregistry.googleapis.com:443' ]
+then
+  export APG_REGISTRY_TOKEN="$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)"
+fi
 
 registry get $REGISTRY_SPEC --contents > /openapi.yaml
 

--- a/containers/prism-registry-mock-server/entrypoint.sh
+++ b/containers/prism-registry-mock-server/entrypoint.sh
@@ -15,11 +15,6 @@
 
 set -ex
 
-if [ "$APG_REGISTRY_ADDRESS" == "apigeeregistry.googleapis.com:443" ]
-then
-  export APG_REGISTRY_TOKEN="$(gcloud auth application-default print-access-token)"
-fi
-
 registry get $REGISTRY_SPEC --contents > /openapi.yaml
 
 prism mock -h "0.0.0.0" /openapi.yaml

--- a/containers/prism-registry-mock-server/entrypoint.sh
+++ b/containers/prism-registry-mock-server/entrypoint.sh
@@ -17,7 +17,7 @@ set -ex
 
 if [ "$APG_REGISTRY_ADDRESS" == "apigeeregistry.googleapis.com:443" ]
 then
-  export APG_REGISTRY_TOKEN="$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)"
+  export APG_REGISTRY_TOKEN="$(gcloud auth application-default print-access-token)"
 fi
 
 registry get $REGISTRY_SPEC --contents > /openapi.yaml

--- a/containers/prism-registry-mock-server/entrypoint.sh
+++ b/containers/prism-registry-mock-server/entrypoint.sh
@@ -13,7 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if [ "$APG_REGISTRY_ADDRESS" == 'apigeeregistry.googleapis.com:443' ]
+set -ex
+
+if [ "$APG_REGISTRY_ADDRESS" == "apigeeregistry.googleapis.com:443" ]
 then
   export APG_REGISTRY_TOKEN="$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)"
 fi

--- a/containers/prism-registry-mock-server/entrypoint.sh
+++ b/containers/prism-registry-mock-server/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/bin/bash
 # Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/containers/prism-registry-mock-server/entrypoint.sh
+++ b/containers/prism-registry-mock-server/entrypoint.sh
@@ -1,4 +1,18 @@
 #!/usr/bin/env sh
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 
 registry get $REGISTRY_SPEC --contents > /openapi.yaml
 

--- a/samples/README.md
+++ b/samples/README.md
@@ -10,7 +10,7 @@ Here are some examples of how to integrate with Apigee Registry.
   * Renderers supported : Swagger UI, GraphiQL, AsyncApi Renderer. 
 
 * **Registy Mock Generator** 
-  * It provides the ability to generate mock endpoints using prism.
+  * It provides the ability to generate mock endpoints using Prism.
   * This sample demonstrates the use of the Controller framework provided 
     by the Apigee Registry project.
   * A custom controller checks the state of the Registry and deploys the prism 

--- a/samples/README.md
+++ b/samples/README.md
@@ -1,0 +1,19 @@
+# Integration examples with Apigee Registry
+
+Here are some examples of how to integrate with Apigee Registry.
+
+> The examples are meant to demonstrate ways to integrate 
+> **Apigee Registry** with your existing tools
+
+* **Registry Spec Renderer** 
+  * It provides a renderer for the specs in your registry.
+  * Renderers supported : Swagger UI, GraphiQL, AsyncApi Renderer. 
+
+* **Registy Mock Generator** 
+  * It provides the ability to generate mock endpoints using prism.
+  * This sample demonstrates the use of the Controller framework provided 
+    by the Apigee Registry project.
+  * A custom controller checks the state of the Registry and deploys the prism 
+    mock service for every OpenAPI specification. 
+  * An artifact (`**_mock-prism-endpoint_**`) is generated, once the mock 
+    service is deployed successfully.

--- a/samples/registry-prism-mock-controller/Dockerfile
+++ b/samples/registry-prism-mock-controller/Dockerfile
@@ -22,6 +22,8 @@ FROM ghcr.io/apigee/registry-tools:latest as registry-tools
 
 FROM gcr.io/cloud-builders/kubectl
 ENV MOCKSERVICE_DOMAIN=""
+ENV APG_REGISTRY_ADDRESS=apigeeregistry.googleapis.com:443
+ENV APG_REGISTRY_INSECURE=0
 
 COPY --from=registry-tools /bin/registry /bin/registry
 COPY --from=registry-tools /bin/apg /bin/apg

--- a/samples/registry-prism-mock-controller/Dockerfile
+++ b/samples/registry-prism-mock-controller/Dockerfile
@@ -32,7 +32,6 @@ COPY ./create-mock.sh /create-mock.sh
 COPY ./docker-entrypoint.sh /docker-entrypoint.sh
 
 COPY ./mock-server-deployment.template.yaml /mock-server-deployment.template.yaml
-COPY ./prism-manifest.yaml /prism-manifest.yaml
 
 RUN apt-get update -y && apt-get install gettext-base -y \
     && chmod +x /create-mock.sh /docker-entrypoint.sh

--- a/samples/registry-prism-mock-controller/Dockerfile
+++ b/samples/registry-prism-mock-controller/Dockerfile
@@ -1,0 +1,38 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Build this image using "envsubst < containers/registry-tools/registry-linters/Dockerfile | docker build -t gcr.io/$REGISTRY_PROJECT_IDENTIFIER/registry-linters -f - ."
+# docker push gcr.io/$REGISTRY_PROJECT_IDENTIFIER/registry-linters:latest
+# Make sure REGISTRY_PROJECT_IDENTIFIER is set
+
+# Build stage
+FROM ghcr.io/apigee/registry-tools:latest as registry-tools
+
+FROM gcr.io/cloud-builders/kubectl
+ENV MOCKSERVICE_DOMAIN=""
+
+COPY --from=registry-tools /bin/registry /bin/registry
+COPY --from=registry-tools /bin/apg /bin/apg
+
+COPY ./create-mock.sh /create-mock.sh
+COPY ./docker-entrypoint.sh /docker-entrypoint.sh
+
+COPY ./mock-server-deployment.template.yaml /mock-server-deployment.template.yaml
+COPY ./prism-manifest.yaml /prism-manifest.yaml
+
+RUN apt-get update -y && apt-get install gettext-base -y \
+    && chmod +x /create-mock.sh /docker-entrypoint.sh
+
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/samples/registry-prism-mock-controller/README.md
+++ b/samples/registry-prism-mock-controller/README.md
@@ -74,8 +74,11 @@ directory.
     ```
 7. Create a custom domain that points to this ip address. You can use sslip.io 
 domain for demonstration purposes. For the IP address 3.4.5.6 use 3-4-5-6.sslip.io 
-
-8. Verify the environment variables and apply the prism controller deployment.
+8. Upload the manifest to the registry
+    ```
+    registry upload manifest ./prism-manifest.yaml --project-id=${REGISTRY_PROJECT_NAME}
+    ```
+9. Verify the environment variables and apply the prism controller deployment.
 ```
     export APG_REGISTRY_ADDRESS=apigeeregistry.googleapis.com:443
     export APG_REGISTRY_INSECURE=0
@@ -85,5 +88,5 @@ domain for demonstration purposes. For the IP address 3.4.5.6 use 3-4-5-6.sslip.
     export CLOUDSDK_COMPUTE_ZONE=us-central1-c 
     envsubst < kubernetes/02-prism-controller.yaml | kubectl apply -f -
 ```
-9. The controller will create an artifact `prism-mock-endpoint` on every spec of type OpenAPI.
+10. The controller will create an artifact `prism-mock-endpoint` on every spec of type OpenAPI.
 

--- a/samples/registry-prism-mock-controller/README.md
+++ b/samples/registry-prism-mock-controller/README.md
@@ -40,9 +40,9 @@ directory.
     --role roles/iam.workloadIdentityUser \
     --member "serviceAccount:${REGISTRY_PROJECT_NAME}.svc.id.goog[prism/registry-admin-sa]"
 
-   kubectl annotate serviceaccount registry-viewer-sa \
+   kubectl annotate serviceaccount registry-admin-sa \
     --namespace prism \
-    iam.gke.io/gcp-service-account=registry-viewer@${REGISTRY_PROJECT_NAME}.iam.gserviceaccount.com
+    iam.gke.io/gcp-service-account=registry-admin@${REGISTRY_PROJECT_NAME}.iam.gserviceaccount.com
    ```
 5. Create a service account with the Apigee Registry Viewer permission (to read specs from the registry)
    ```
@@ -63,9 +63,9 @@ directory.
     --role roles/iam.workloadIdentityUser \
     --member "serviceAccount:${REGISTRY_PROJECT_NAME}.svc.id.goog[prism/registry-viewer-sa]"
 
-   kubectl annotate serviceaccount registry-admin-sa \
+   kubectl annotate serviceaccount registry-viewer-sa \
     --namespace prism \
-    iam.gke.io/gcp-service-account=registry-admin@${REGISTRY_PROJECT_NAME}.iam.gserviceaccount.com
+    iam.gke.io/gcp-service-account=registry-viewer@${REGISTRY_PROJECT_NAME}.iam.gserviceaccount.com
 
    ```
 6. Get the external IP address of Istio Ingress Gateway
@@ -79,7 +79,7 @@ domain for demonstration purposes. For the IP address 3.4.5.6 use 3-4-5-6.sslip.
     registry upload manifest ./prism-manifest.yaml --project-id=${REGISTRY_PROJECT_NAME}
     ```
 9. Verify the environment variables and apply the prism controller deployment.
-```
+    ```
     export APG_REGISTRY_ADDRESS=apigeeregistry.googleapis.com:443
     export APG_REGISTRY_INSECURE=0
     export MOCKSERVICE_DOMAIN=3-4-5-6.sslip.io
@@ -87,6 +87,6 @@ domain for demonstration purposes. For the IP address 3.4.5.6 use 3-4-5-6.sslip.
     export CLOUDSDK_CONTAINER_CLUSTER=registry-mock-server-cluster
     export CLOUDSDK_COMPUTE_ZONE=us-central1-c 
     envsubst < kubernetes/02-prism-controller.yaml | kubectl apply -f -
-```
+    ```
 10. The controller will create an artifact `prism-mock-endpoint` on every spec of type OpenAPI.
 

--- a/samples/registry-prism-mock-controller/README.md
+++ b/samples/registry-prism-mock-controller/README.md
@@ -1,9 +1,72 @@
-# Prism Mock controller
+# Registy Mock Generator
 
+* It provides the ability to generate mock endpoints using Prism.
+* A custom controller (extends the base registry controller framework) checks 
+  the state of the Registry and deploys the prism mock service for every 
+  OpenAPI specification.
+* An artifact (`**_mock-prism-endpoint_**`) is generated, once the mock
+  service is deployed successfully.
+
+
+### Installations steps
+
+The setup uses a GKE Cluster with ASM (Anthos Service Mesh). 
+To use Istio please modify the configurations files in [kubernetes](kubenertes) 
+directory. 
+1. Create a GKE cluster, named `registry-mock-server-cluster` with ASM and workload identity enabled 
+2. Connect to the cluster
+3. Apply the ASM configuration
+   ```
+    kubectl apply -f kubenetes/01-asm-configuation.yaml
+   ```
+4. Create a service account with Registry Admin role (for the controller to write back artifacts)
+   ```
+   export REGISTRY_PROJECT_NAME=openapi
+
+   gcloud iam service-accounts create registry-admin \
+    --project=${REGISTRY_PROJECT_NAME}
+   
+   gcloud projects add-iam-policy-binding registry-admin \
+    --member "serviceAccount:registry-admin@${REGISTRY_PROJECT_NAME}.iam.gserviceaccount.com" \
+    --role "roles/apigeeregistry.admin"
+
+   gcloud iam service-accounts add-iam-policy-binding registry-admin@${REGISTRY_PROJECT_NAME}.iam.gserviceaccount.com \
+    --role roles/iam.workloadIdentityUser \
+    --member "serviceAccount:registry-admin.svc.id.goog[prism/registry-admin-sa]"
+
+   ```
+5. Create a service account with the Apigee Registry Viewer permission (to read specs from the registry)
+   ```
+   export REGISTRY_PROJECT_NAME=openapi
+
+   gcloud iam service-accounts create registry-viewer \
+    --project=${REGISTRY_PROJECT_NAME}
+   
+   gcloud projects add-iam-policy-binding registry-viewer \
+    --member "serviceAccount:registry-viewer@${REGISTRY_PROJECT_NAME}.iam.gserviceaccount.com" \
+    --role "roles/apigeeregistry.viewer"
+
+   gcloud iam service-accounts add-iam-policy-binding registry-viewer@${REGISTRY_PROJECT_NAME}.iam.gserviceaccount.com \
+    --role roles/iam.workloadIdentityUser \
+    --member "serviceAccount:registry-viewer.svc.id.goog[prism/registry-viewer-sa]"
+
+   ```
+6. Get the external IP address of Istio Ingress Gateway
+    ```
+    echo $(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+    ```
+7. Create a custom domain that points to this ip address. You can use sslip.io 
+domain for demonstration purposes. For the IP address 3.4.5.6 use 3-4-5-6.sslip.io 
+
+8. Verify the environment variables and apply the prism controller deployment.
 ```
-    MOCKSERVICE_DOMAIN=35-192-38-57.sslip.io
-    REGISTRY_PROJECT_NAME=openapi
-    CLOUDSDK_CONTAINER_CLUSTER=registry-mock-server-cluster
-    CLOUDSDK_COMPUTE_ZONE=us-central1-c 
+    export APG_REGISTRY_ADDRESS=apigeeregistry.googleapis.com:443
+    export APG_REGISTRY_INSECURE=0
+    export MOCKSERVICE_DOMAIN=3-4-5-6.sslip.io
+    export REGISTRY_PROJECT_NAME=openapi
+    export CLOUDSDK_CONTAINER_CLUSTER=registry-mock-server-cluster
+    export CLOUDSDK_COMPUTE_ZONE=us-central1-c 
     envsubst < 02-prism-controller.yaml | kubectl apply -f -
 ```
+9. The controller will create an artifact `prism-mock-endpoint` on every spec of type OpenAPI.
+

--- a/samples/registry-prism-mock-controller/README.md
+++ b/samples/registry-prism-mock-controller/README.md
@@ -21,7 +21,7 @@ directory.
    ```
 4. Create a service account with Registry Admin role (for the controller to write back artifacts)
    ```
-   export REGISTRY_PROJECT_NAME=apihub-demo-fossa
+   export REGISTRY_PROJECT_NAME=openapi
    
    gcloud config set project $REGISTRY_PROJECT_NAME
    
@@ -31,6 +31,10 @@ directory.
    gcloud projects add-iam-policy-binding registry-admin \
     --member "serviceAccount:registry-admin@${REGISTRY_PROJECT_NAME}.iam.gserviceaccount.com" \
     --role "roles/apigeeregistry.admin"
+
+   gcloud projects add-iam-policy-binding registry-admin \
+    --member "serviceAccount:registry-admin@${REGISTRY_PROJECT_NAME}.iam.gserviceaccount.com" \
+    --role "roles/logging.logWriter"
 
    gcloud iam service-accounts add-iam-policy-binding registry-admin@${REGISTRY_PROJECT_NAME}.iam.gserviceaccount.com \
     --role roles/iam.workloadIdentityUser \
@@ -50,6 +54,10 @@ directory.
    gcloud projects add-iam-policy-binding registry-viewer \
     --member "serviceAccount:registry-viewer@${REGISTRY_PROJECT_NAME}.iam.gserviceaccount.com" \
     --role "roles/apigeeregistry.viewer"
+
+   gcloud projects add-iam-policy-binding registry-viewer \
+    --member "serviceAccount:registry-viewer@${REGISTRY_PROJECT_NAME}.iam.gserviceaccount.com" \
+    --role "roles/logging.logWriter"
 
    gcloud iam service-accounts add-iam-policy-binding registry-viewer@${REGISTRY_PROJECT_NAME}.iam.gserviceaccount.com \
     --role roles/iam.workloadIdentityUser \

--- a/samples/registry-prism-mock-controller/README.md
+++ b/samples/registry-prism-mock-controller/README.md
@@ -1,0 +1,9 @@
+# Prism Mock controller
+
+```
+    MOCKSERVICE_DOMAIN=35-192-38-57.sslip.io
+    REGISTRY_PROJECT_NAME=openapi
+    CLOUDSDK_CONTAINER_CLUSTER=registry-mock-server-cluster
+    CLOUDSDK_COMPUTE_ZONE=us-central1-c 
+    envsubst < 02-prism-controller.yaml | kubectl apply -f -
+```

--- a/samples/registry-prism-mock-controller/create-mock.sh
+++ b/samples/registry-prism-mock-controller/create-mock.sh
@@ -26,6 +26,10 @@ SPEC="$(echo $REGISTRY_SPEC | cut -d "/" -f10)"
 
 export REGISTRY_VERSION_SPEC="$API-$VERSION-$SPEC"
 export MOCK_SERVICE_ENDPOINT="mock-${REGISTRY_VERSION_SPEC}.${MOCKSERVICE_DOMAIN}"
+if [ "$APG_REGISTRY_ADDRESS" == 'apigeeregistry.googleapis.com:443' ]
+then
+  export APG_REGISTRY_TOKEN="$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)"
+fi
 
 cat /mock-server-deployment.template.yaml | envsubst > /tmp/mock-server-deployment-${REGISTRY_VERSION_SPEC}.yaml
 

--- a/samples/registry-prism-mock-controller/create-mock.sh
+++ b/samples/registry-prism-mock-controller/create-mock.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+set -ex
+
+export REGISTRY_SPEC=$1
+
+# REGISTRY_SPEC is in  format projects/p1/locations/global/apis/ap1/versions/v1/specs/spec1
+echo $REGISTRY_SPEC | cut -d "/" -f6
+API="$(echo $REGISTRY_SPEC | cut -d "/" -f6)"
+VERSION="$(echo $REGISTRY_SPEC | cut -d "/" -f8)"
+SPEC="$(echo $REGISTRY_SPEC | cut -d "/" -f10)"
+
+export REGISTRY_VERSION_SPEC="$API-$VERSION-$SPEC"
+export MOCK_SERVICE_ENDPOINT="mock-${REGISTRY_VERSION_SPEC}.${MOCKSERVICE_DOMAIN}"
+
+cat /mock-server-deployment.template.yaml | envsubst > /tmp/mock-server-deployment-${REGISTRY_VERSION_SPEC}.yaml
+
+kubectl apply -f /tmp/mock-server-deployment-${REGISTRY_VERSION_SPEC}.yaml
+
+apg registry create-artifact \
+  --parent $REGISTRY_SPEC \
+  --artifact_id "prism-mock-endpoint" \
+  --artifact.mime_type "text/plain" \
+  --artifact.contents $(echo $MOCK_SERVICE_ENDPOINT | od -A n -t x1) \
+  --json

--- a/samples/registry-prism-mock-controller/create-mock.sh
+++ b/samples/registry-prism-mock-controller/create-mock.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/samples/registry-prism-mock-controller/create-mock.sh
+++ b/samples/registry-prism-mock-controller/create-mock.sh
@@ -26,14 +26,15 @@ SPEC="$(echo $REGISTRY_SPEC | cut -d "/" -f10)"
 
 export REGISTRY_VERSION_SPEC="$API-$VERSION-$SPEC"
 export MOCK_SERVICE_ENDPOINT="mock-${REGISTRY_VERSION_SPEC}.${MOCKSERVICE_DOMAIN}"
-if [ "$APG_REGISTRY_ADDRESS" == 'apigeeregistry.googleapis.com:443' ]
-then
-  export APG_REGISTRY_TOKEN="$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)"
-fi
 
 cat /mock-server-deployment.template.yaml | envsubst > /tmp/mock-server-deployment-${REGISTRY_VERSION_SPEC}.yaml
 
 kubectl apply -f /tmp/mock-server-deployment-${REGISTRY_VERSION_SPEC}.yaml
+
+if [ "$APG_REGISTRY_ADDRESS" == "apigeeregistry.googleapis.com:443" ]
+then
+  export APG_REGISTRY_TOKEN="$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)"
+fi
 
 apg registry create-artifact \
   --parent $REGISTRY_SPEC \

--- a/samples/registry-prism-mock-controller/create-mock.sh
+++ b/samples/registry-prism-mock-controller/create-mock.sh
@@ -24,7 +24,7 @@ API="$(echo $REGISTRY_SPEC | cut -d "/" -f6)"
 VERSION="$(echo $REGISTRY_SPEC | cut -d "/" -f8)"
 SPEC="$(echo $REGISTRY_SPEC | cut -d "/" -f10)"
 
-export REGISTRY_VERSION_SPEC="$API-$VERSION-$SPEC"
+export REGISTRY_VERSION_SPEC="$(echo $API-$VERSION-$SPEC | sed 's/[^a-zA-Z0-9\-]/-/g')"
 export MOCK_SERVICE_ENDPOINT="mock-${REGISTRY_VERSION_SPEC}.${MOCKSERVICE_DOMAIN}"
 
 cat /mock-server-deployment.template.yaml | envsubst > /tmp/mock-server-deployment-${REGISTRY_VERSION_SPEC}.yaml
@@ -33,7 +33,7 @@ kubectl apply -f /tmp/mock-server-deployment-${REGISTRY_VERSION_SPEC}.yaml
 
 if [ "$APG_REGISTRY_ADDRESS" == "apigeeregistry.googleapis.com:443" ]
 then
-  export APG_REGISTRY_TOKEN="$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)"
+  export APG_REGISTRY_TOKEN="$(gcloud auth application-default print-access-token)"
 fi
 
 apg registry create-artifact \

--- a/samples/registry-prism-mock-controller/create-mock.sh
+++ b/samples/registry-prism-mock-controller/create-mock.sh
@@ -31,11 +31,6 @@ cat /mock-server-deployment.template.yaml | envsubst > /tmp/mock-server-deployme
 
 kubectl apply -f /tmp/mock-server-deployment-${REGISTRY_VERSION_SPEC}.yaml
 
-if [ "$APG_REGISTRY_ADDRESS" == "apigeeregistry.googleapis.com:443" ]
-then
-  export APG_REGISTRY_TOKEN="$(gcloud auth application-default print-access-token)"
-fi
-
 apg registry create-artifact \
   --parent $REGISTRY_SPEC \
   --artifact_id "prism-mock-endpoint" \

--- a/samples/registry-prism-mock-controller/create-mock.sh
+++ b/samples/registry-prism-mock-controller/create-mock.sh
@@ -1,4 +1,18 @@
 #!/bin/sh
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 
 set -ex
 

--- a/samples/registry-prism-mock-controller/docker-entrypoint.sh
+++ b/samples/registry-prism-mock-controller/docker-entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -ex
+
+registry upload manifest /prism-manifest.yaml --project-id=${REGISTRY_PROJECT_NAME} || true
+
+registry resolve projects/${REGISTRY_PROJECT_NAME}/locations/global/artifacts/apihub-prism-mocker-manifest
+
+rc=$(echo $?)
+
+curl -fsI -X POST http://localhost:15020/quitquitquit
+
+exit $rc

--- a/samples/registry-prism-mock-controller/docker-entrypoint.sh
+++ b/samples/registry-prism-mock-controller/docker-entrypoint.sh
@@ -16,6 +16,11 @@
 
 set -ex
 
+if [ "$APG_REGISTRY_ADDRESS" == 'apigeeregistry.googleapis.com:443' ]
+then
+  export APG_REGISTRY_TOKEN="$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)"
+fi
+
 registry upload manifest /prism-manifest.yaml --project-id=${REGISTRY_PROJECT_NAME} || true
 
 registry resolve projects/${REGISTRY_PROJECT_NAME}/locations/global/artifacts/apihub-prism-mocker-manifest

--- a/samples/registry-prism-mock-controller/docker-entrypoint.sh
+++ b/samples/registry-prism-mock-controller/docker-entrypoint.sh
@@ -16,11 +16,6 @@
 
 set -ex
 
-if [ "$APG_REGISTRY_ADDRESS" == "apigeeregistry.googleapis.com:443" ]
-then
-  export APG_REGISTRY_TOKEN="$(gcloud auth application-default print-access-token)"
-fi
-
 registry resolve projects/${REGISTRY_PROJECT_NAME}/locations/global/artifacts/apihub-prism-mocker-manifest
 
 rc=$(echo $?)

--- a/samples/registry-prism-mock-controller/docker-entrypoint.sh
+++ b/samples/registry-prism-mock-controller/docker-entrypoint.sh
@@ -18,7 +18,7 @@ set -ex
 
 if [ "$APG_REGISTRY_ADDRESS" == "apigeeregistry.googleapis.com:443" ]
 then
-  export APG_REGISTRY_TOKEN="$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)"
+  export APG_REGISTRY_TOKEN="$(gcloud auth application-default print-access-token)"
 fi
 
 registry resolve projects/${REGISTRY_PROJECT_NAME}/locations/global/artifacts/apihub-prism-mocker-manifest

--- a/samples/registry-prism-mock-controller/docker-entrypoint.sh
+++ b/samples/registry-prism-mock-controller/docker-entrypoint.sh
@@ -18,7 +18,7 @@ set -ex
 
 if [ "$APG_REGISTRY_ADDRESS" == "apigeeregistry.googleapis.com:443" ]
 then
-  export APG_REGISTRY_TOKEN="$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)"
+  export APG_REGISTRY_TOKEN="$(gcloud auth print-access-token)"
 fi
 
 registry upload manifest /prism-manifest.yaml --project-id=${REGISTRY_PROJECT_NAME} || true

--- a/samples/registry-prism-mock-controller/docker-entrypoint.sh
+++ b/samples/registry-prism-mock-controller/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/samples/registry-prism-mock-controller/docker-entrypoint.sh
+++ b/samples/registry-prism-mock-controller/docker-entrypoint.sh
@@ -18,7 +18,7 @@ set -ex
 
 if [ "$APG_REGISTRY_ADDRESS" == "apigeeregistry.googleapis.com:443" ]
 then
-  export APG_REGISTRY_TOKEN="$(gcloud auth print-access-token)"
+  export APG_REGISTRY_TOKEN="$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)"
 fi
 
 registry resolve projects/${REGISTRY_PROJECT_NAME}/locations/global/artifacts/apihub-prism-mocker-manifest

--- a/samples/registry-prism-mock-controller/docker-entrypoint.sh
+++ b/samples/registry-prism-mock-controller/docker-entrypoint.sh
@@ -16,7 +16,7 @@
 
 set -ex
 
-if [ "$APG_REGISTRY_ADDRESS" == 'apigeeregistry.googleapis.com:443' ]
+if [ "$APG_REGISTRY_ADDRESS" == "apigeeregistry.googleapis.com:443" ]
 then
   export APG_REGISTRY_TOKEN="$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)"
 fi

--- a/samples/registry-prism-mock-controller/docker-entrypoint.sh
+++ b/samples/registry-prism-mock-controller/docker-entrypoint.sh
@@ -21,8 +21,6 @@ then
   export APG_REGISTRY_TOKEN="$(gcloud auth print-access-token)"
 fi
 
-registry upload manifest /prism-manifest.yaml --project-id=${REGISTRY_PROJECT_NAME} || true
-
 registry resolve projects/${REGISTRY_PROJECT_NAME}/locations/global/artifacts/apihub-prism-mocker-manifest
 
 rc=$(echo $?)

--- a/samples/registry-prism-mock-controller/docker-entrypoint.sh
+++ b/samples/registry-prism-mock-controller/docker-entrypoint.sh
@@ -1,4 +1,18 @@
 #!/bin/sh
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 
 set -ex
 

--- a/samples/registry-prism-mock-controller/kubernetes/01-asm-configuration.yaml
+++ b/samples/registry-prism-mock-controller/kubernetes/01-asm-configuration.yaml
@@ -1,3 +1,17 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/samples/registry-prism-mock-controller/kubernetes/01-asm-configuration.yaml
+++ b/samples/registry-prism-mock-controller/kubernetes/01-asm-configuration.yaml
@@ -90,3 +90,20 @@ kind: ServiceAccount
 metadata:
   name: registry-admin-sa
   namespace: prism
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: mock-server-gateway
+  namespace: prism
+spec:
+  selector:
+    istio: ingressgateway # use istio default controller
+  servers:
+  - port:
+      number: 80
+      name: http
+      protocol: HTTP
+    hosts:
+    - "*"
+---

--- a/samples/registry-prism-mock-controller/kubernetes/01-asm-configuration.yaml
+++ b/samples/registry-prism-mock-controller/kubernetes/01-asm-configuration.yaml
@@ -16,6 +16,10 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: istio-system
+  labels: {
+    "istio.io/rev": "asm-managed"
+  }
+
 ---
 apiVersion: mesh.cloud.google.com/v1alpha1
 kind: ControlPlaneRevision
@@ -27,21 +31,12 @@ spec:
   channel: regular
 ---
 apiVersion: v1
-kind: Namespace
-metadata:
-  name: istio-system
-  labels: {
-    "istio.io/rev": "asm-managed"
-  }
-
----
-apiVersion: v1
 kind: Service
 metadata:
   name: istio-ingressgateway
   namespace: istio-system
-#  annotations:
-#    networking.gke.io/load-balancer-type: "Internal"
+  annotations:
+    networking.gke.io/load-balancer-type: "Internal"
 spec:
   type: LoadBalancer
   selector:
@@ -75,3 +70,23 @@ spec:
       containers:
       - name: istio-proxy
         image: auto # The image will automatically update each time the pod starts.
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: prism
+  labels: {
+    "istio.io/rev": "asm-managed"
+  }
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: registry-viewer-sa
+  namespace: prism
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: registry-admin-sa
+  namespace: prism

--- a/samples/registry-prism-mock-controller/kubernetes/01-asm-configuration.yaml
+++ b/samples/registry-prism-mock-controller/kubernetes/01-asm-configuration.yaml
@@ -1,0 +1,63 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: istio-system
+---
+apiVersion: mesh.cloud.google.com/v1alpha1
+kind: ControlPlaneRevision
+metadata:
+  name: asm-managed
+  namespace: istio-system
+spec:
+  type: managed_service
+  channel: regular
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: istio-system
+  labels: {
+    "istio.io/rev": "asm-managed"
+  }
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: istio-ingressgateway
+  namespace: istio-system
+#  annotations:
+#    networking.gke.io/load-balancer-type: "Internal"
+spec:
+  type: LoadBalancer
+  selector:
+    istio: ingressgateway
+  ports:
+  - port: 80
+    name: http
+  - port: 443
+    name: https
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: istio-ingressgateway
+  namespace: istio-system
+spec:
+  selector:
+    matchLabels:
+      istio: ingressgateway
+  template:
+    metadata:
+      annotations:
+        # This is required to tell Anthos Service Mesh to inject the gateway with the
+        # required configuration.
+        inject.istio.io/templates: gateway
+      labels:
+        istio: ingressgateway
+        istio.io/rev: asm-managed # This is required only if the namespace is not labeled.
+    spec:
+      containers:
+      - name: istio-proxy
+        image: auto # The image will automatically update each time the pod starts.

--- a/samples/registry-prism-mock-controller/kubernetes/02-prism-controller.yaml
+++ b/samples/registry-prism-mock-controller/kubernetes/02-prism-controller.yaml
@@ -1,3 +1,17 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/samples/registry-prism-mock-controller/kubernetes/02-prism-controller.yaml
+++ b/samples/registry-prism-mock-controller/kubernetes/02-prism-controller.yaml
@@ -90,7 +90,7 @@ spec:
           containers:
           - name: registry-prism-mocker
             image: ghcr.io/giteshk-org/registry-prism-mock-controller:api-mocker
-            imagePullPolicy: IfNotPresent
+            imagePullPolicy: Always
             env:
             - name: APG_REGISTRY_ADDRESS
               value: "${APG_REGISTRY_ADDRESS}"

--- a/samples/registry-prism-mock-controller/kubernetes/02-prism-controller.yaml
+++ b/samples/registry-prism-mock-controller/kubernetes/02-prism-controller.yaml
@@ -12,14 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: prism
-  labels: {
-    "istio.io/rev": "asm-managed"
-  }
----
 apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
@@ -35,18 +27,6 @@ spec:
       protocol: HTTP
     hosts:
     - "*"
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: registry-viewer-sa
-  namespace: prism
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: registry-admin-sa
-  namespace: prism
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -109,8 +89,8 @@ spec:
             iam.gke.io/gke-metadata-server-enabled: "true"
           containers:
           - name: registry-prism-mocker
-            image: ghcr.io/apigee/registry-prism-mock-controller:latest
-            imagePullPolicy: Always
+            image: ghcr.io/giteshk-org/registry-prism-mock-controller:api-mocker
+            imagePullPolicy: IfNotPresent
             env:
             - name: APG_REGISTRY_ADDRESS
               value: "${APG_REGISTRY_ADDRESS}"

--- a/samples/registry-prism-mock-controller/kubernetes/02-prism-controller.yaml
+++ b/samples/registry-prism-mock-controller/kubernetes/02-prism-controller.yaml
@@ -25,7 +25,13 @@ spec:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: mock-server-admin-sa
+  name: registry-viewer-sa
+  namespace: prism
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: registry-admin-sa
   namespace: prism
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -56,7 +62,7 @@ metadata:
   namespace: prism
 subjects:
 - kind: ServiceAccount
-  name: mock-server-admin-sa
+  name: registry-admin-sa
 roleRef:
   kind: Role
   name: create-mock-server-role
@@ -84,7 +90,9 @@ spec:
           labels:
             app: registry-prism-cronjob
         spec:
-          serviceAccountName: mock-server-admin-sa
+          serviceAccountName: registry-admin-sa
+          nodeSelector:
+            iam.gke.io/gke-metadata-server-enabled: "true"
           containers:
           - name: registry-prism-mocker
             image: ghcr.io/giteshk-org/registry-prism-mock-controller:api-mocker

--- a/samples/registry-prism-mock-controller/kubernetes/02-prism-controller.yaml
+++ b/samples/registry-prism-mock-controller/kubernetes/02-prism-controller.yaml
@@ -12,22 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: networking.istio.io/v1alpha3
-kind: Gateway
-metadata:
-  name: mock-server-gateway
-  namespace: prism
-spec:
-  selector:
-    istio: ingressgateway # use istio default controller
-  servers:
-  - port:
-      number: 80
-      name: http
-      protocol: HTTP
-    hosts:
-    - "*"
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/samples/registry-prism-mock-controller/kubernetes/02-prism-controller.yaml
+++ b/samples/registry-prism-mock-controller/kubernetes/02-prism-controller.yaml
@@ -95,7 +95,7 @@ spec:
             iam.gke.io/gke-metadata-server-enabled: "true"
           containers:
           - name: registry-prism-mocker
-            image: ghcr.io/giteshk-org/registry-prism-mock-controller:api-mocker
+            image: ghcr.io/apigee/registry-prism-mock-controller:latest
             imagePullPolicy: Always
             env:
             - name: APG_REGISTRY_ADDRESS

--- a/samples/registry-prism-mock-controller/kubernetes/02-prism-controller.yaml
+++ b/samples/registry-prism-mock-controller/kubernetes/02-prism-controller.yaml
@@ -1,0 +1,108 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: prism
+  labels: {
+    "istio.io/rev": "asm-managed"
+  }
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: mock-server-gateway
+  namespace: prism
+spec:
+  selector:
+    istio: ingressgateway # use istio default controller
+  servers:
+  - port:
+      number: 80
+      name: http
+      protocol: HTTP
+    hosts:
+    - "*"
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mock-server-admin-sa
+  namespace: prism
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: create-mock-server-role
+  namespace: prism
+rules:
+- apiGroups:
+  - ""
+  - "apps"
+  - "networking.istio.io"
+  resources:
+  - deployments
+  - services
+  - virtualservices
+  verbs:
+  - get
+  - create
+  - update
+  - list
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: create-mock-service-role-binding
+  namespace: prism
+subjects:
+- kind: ServiceAccount
+  name: mock-server-admin-sa
+roleRef:
+  kind: Role
+  name: create-mock-server-role
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: registry-prism-cronjob
+  namespace: prism
+spec:
+  schedule: "*/5 * * * *"
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 100
+  suspend: false
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    metadata:
+      labels:
+        app: registry-prism-cronjob
+    spec:
+      template:
+        metadata:
+          labels:
+            app: registry-prism-cronjob
+        spec:
+          serviceAccountName: mock-server-admin-sa
+          containers:
+          - name: registry-prism-mocker
+            image: ghcr.io/giteshk-org/registry-prism-mock-controller:api-mocker
+            imagePullPolicy: Always
+            env:
+            - name: APG_REGISTRY_ADDRESS
+              value: "${APG_REGISTRY_ADDRESS}"
+            - name: APG_REGISTRY_INSECURE
+              value: "${APG_REGISTRY_INSECURE}"
+            - name: REGISTRY_PROJECT_NAME
+              value: "${REGISTRY_PROJECT_NAME}"
+            - name: MOCKSERVICE_DOMAIN
+              value: "${MOCKSERVICE_DOMAIN}"
+            - name: CLOUDSDK_CONTAINER_CLUSTER
+              value: "${CLOUDSDK_CONTAINER_CLUSTER}"
+#            - name: CLOUDSDK_COMPUTE_REGION
+#              value: "${MOCKSERVICE_GKE_LOCATION}"
+            - name: CLOUDSDK_COMPUTE_ZONE
+              value: "${CLOUDSDK_COMPUTE_ZONE}"
+          restartPolicy: Never
+      backoffLimit: 3

--- a/samples/registry-prism-mock-controller/mock-server-deployment.template.yaml
+++ b/samples/registry-prism-mock-controller/mock-server-deployment.template.yaml
@@ -34,7 +34,7 @@ spec:
         iam.gke.io/gke-metadata-server-enabled: "true"
       containers:
       - name: mock-server
-        image: ghcr.io/apigee/prism-registry-mock-server:latest
+        image: ghcr.io/giteshk-org/prism-registry-mock-server:api-mocker
         imagePullPolicy: Always
         env:
         - name: PORT

--- a/samples/registry-prism-mock-controller/mock-server-deployment.template.yaml
+++ b/samples/registry-prism-mock-controller/mock-server-deployment.template.yaml
@@ -1,0 +1,82 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Deployment for the Registry Server
+#
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mock-${REGISTRY_VERSION_SPEC}-server
+  namespace: prism
+spec:
+  selector:
+    matchLabels:
+      app: mock-${REGISTRY_VERSION_SPEC}-server
+  template:
+    metadata:
+      labels:
+        app: mock-${REGISTRY_VERSION_SPEC}-server
+    spec:
+      containers:
+      - name: mock-server
+        image: ghcr.io/giteshk-org/prism-registry-mock-server:api-mocker
+        imagePullPolicy: Always
+        env:
+        - name: PORT
+          value: "4010"
+        - name: REGISTRY_SPEC
+          value: "${REGISTRY_SPEC}"
+        - name: APG_REGISTRY_ADDRESS
+          value: "${APG_REGISTRY_ADDRESS}"
+        - name: APG_REGISTRY_INSECURE
+          value: "${APG_REGISTRY_INSECURE}"
+        ports:
+        - containerPort: 4010
+          protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mock-${REGISTRY_VERSION_SPEC}-lb
+  namespace: prism
+  labels:
+    app: mock-${REGISTRY_VERSION_SPEC}-server
+spec:
+  type: ClusterIP
+  selector:
+    app: mock-${REGISTRY_VERSION_SPEC}-server
+  ports:
+  - protocol: TCP
+    port: 4010
+    targetPort: 4010
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: mock-${REGISTRY_VERSION_SPEC}-virtualservice
+  namespace: prism
+  labels:
+    app: mock-${REGISTRY_VERSION_SPEC}-server
+spec:
+  hosts:
+  - ${MOCK_SERVICE_ENDPOINT}
+  gateways:
+  - mock-server-gateway
+  http:
+  - route:
+    - destination:
+        host: mock-${REGISTRY_VERSION_SPEC}-lb.prism.svc.cluster.local
+        port:
+          number: 4010

--- a/samples/registry-prism-mock-controller/mock-server-deployment.template.yaml
+++ b/samples/registry-prism-mock-controller/mock-server-deployment.template.yaml
@@ -34,7 +34,7 @@ spec:
         iam.gke.io/gke-metadata-server-enabled: "true"
       containers:
       - name: mock-server
-        image: ghcr.io/giteshk-org/prism-registry-mock-server:api-mocker
+        image: ghcr.io/apigee/prism-registry-mock-server:latest
         imagePullPolicy: Always
         env:
         - name: PORT

--- a/samples/registry-prism-mock-controller/mock-server-deployment.template.yaml
+++ b/samples/registry-prism-mock-controller/mock-server-deployment.template.yaml
@@ -29,6 +29,9 @@ spec:
       labels:
         app: mock-${REGISTRY_VERSION_SPEC}-server
     spec:
+      serviceAccountName: registry-viewer-sa
+      nodeSelector:
+        iam.gke.io/gke-metadata-server-enabled: "true"
       containers:
       - name: mock-server
         image: ghcr.io/giteshk-org/prism-registry-mock-server:api-mocker

--- a/samples/registry-prism-mock-controller/prism-manifest.yaml
+++ b/samples/registry-prism-mock-controller/prism-manifest.yaml
@@ -1,0 +1,20 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+id: apihub-prism-mocker-manifest
+generated_resources:
+- pattern: apis/-/versions/-/specs/-/artifacts/prism-mock-endpoint
+  dependencies:
+  - pattern: $resource.spec
+    filter: "mime_type.contains('openapi')"
+  action: "/create-mock.sh $resource.spec"


### PR DESCRIPTION
* Added a custom controller to create mock server for OpenAPI specs in the registry.
* Write back the mock server endpoint as artifact to the spec in registry