### PR TITLE
Create a mock handler and spec renderer for API deployments.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -37,7 +37,7 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v2
       with:
-        version: v1.36
+        version: v1.45
         args: --timeout 5m0s
 
     - name: Install

--- a/containers/registry-mock-server/openapi/README.md
+++ b/containers/registry-mock-server/openapi/README.md
@@ -7,9 +7,27 @@ For a registry spec 'projects/openapi/locations/global/apis/benchtest-1/versions
 The mock service will be available at
 http://localhost:3000/projects/openapi/locations/global/apis/benchtest-1/versions/v1/specs/spec-1
 
-Mock service is also available at http://localhost:3000/mock 
-by passing the header specifying the spec path
-`apigee-registry-spec: projects/openapi/locations/global/apis/benchtest-1/versions/v1/specs/spec-1`
+### To run this service on a GCE instance run the following command:
+```
+export REGISTRY_PROJECT_IDENTIFIER=$(gcloud config list --format 'value(core.project)')
+gcloud iam service-accounts create registry-viewer \
+    --description="Registry Reader" \
+    --display-name="Registry Reader"
+
+gcloud projects add-iam-policy-binding $REGISTRY_PROJECT_IDENTIFIER \
+    --member="serviceAccount:registry-viewer@$REGISTRY_PROJECT_IDENTIFIER.iam.gserviceaccount.com" \
+    --role="roles/apigeeregistry.viewer"
+
+gcloud compute firewall-rules create registry-mock-service-fw \
+    --action allow \
+    --target-tags registry-mock-service \
+    --source-ranges 0.0.0.0/0 \
+    --rules tcp:80
 
 
-[![Run on Google Cloud](https://deploy.cloud.run/button.svg)](https://deploy.cloud.run)
+gcloud compute instances create-with-container registry-mock-server-instance \
+	--machine-type=e2-micro  --tags=registry-mock-service,http-server \
+	--scopes=https://www.googleapis.com/auth/cloud-platform \
+	--restart-on-failure --service-account=registry-viewer@$REGISTRY_PROJECT_IDENTIFIER.iam.gserviceaccount.com\
+    --container-image ghcr.io/apigee/registry-prism-mock-server:main
+```

--- a/containers/registry-mock-server/openapi/package.json
+++ b/containers/registry-mock-server/openapi/package.json
@@ -17,13 +17,13 @@
     "cors": "^2.8.5",
     "express": "^4.17.3",
     "google-gax": "^2.30.1",
-    "js-yaml": "^4.1.0"
+    "js-yaml": "^4.1.0",
+    "@grpc/grpc-js": "^1.5.9"
   },
   "files": [
     "/dist"
   ],
   "devDependencies": {
-    "@grpc/grpc-js": "^1.5.9",
     "@stoplight/types": "^12.5.0",
     "@types/cors": "^2.8.12",
     "@types/express": "^4.17.13",

--- a/containers/registry-mock-server/openapi/package.json
+++ b/containers/registry-mock-server/openapi/package.json
@@ -4,7 +4,7 @@
   "description": "Prism mock server for openapi specs stored in Apigee Registry",
   "scripts": {
     "start": "node dist/index.js",
-    "build": "npm dedupe && rm -f dist/* && tsc",
+    "build": "rm -f dist/* && tsc",
     "fix": "gts fix",
     "lint": "gts check"
   },
@@ -12,6 +12,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@giteshk-org/apigeeregistry": "^0.0.1",
+    "@grpc/grpc-js": "^1.5.9",
     "@stoplight/prism-cli": "^4.8.0",
     "@stoplight/prism-http": "^4.8.0",
     "cors": "^2.8.5",
@@ -23,7 +24,6 @@
     "/dist"
   ],
   "devDependencies": {
-    "@grpc/grpc-js": "^1.5.9",
     "@stoplight/types": "^12.5.0",
     "@types/cors": "^2.8.12",
     "@types/express": "^4.17.13",

--- a/containers/registry-mock-server/openapi/package.json
+++ b/containers/registry-mock-server/openapi/package.json
@@ -4,7 +4,7 @@
   "description": "Prism mock server for openapi specs stored in Apigee Registry",
   "scripts": {
     "start": "node dist/index.js",
-    "build": "rm -f dist/* && tsc",
+    "build": "npm dedupe && rm -f dist/* && tsc",
     "fix": "gts fix",
     "lint": "gts check"
   },
@@ -12,7 +12,6 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@giteshk-org/apigeeregistry": "^0.0.1",
-    "@grpc/grpc-js": "^1.5.9",
     "@stoplight/prism-cli": "^4.8.0",
     "@stoplight/prism-http": "^4.8.0",
     "cors": "^2.8.5",
@@ -24,6 +23,7 @@
     "/dist"
   ],
   "devDependencies": {
+    "@grpc/grpc-js": "^1.5.9",
     "@stoplight/types": "^12.5.0",
     "@types/cors": "^2.8.12",
     "@types/express": "^4.17.13",

--- a/containers/registry-mock-server/openapi/src/index.ts
+++ b/containers/registry-mock-server/openapi/src/index.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import * as express from 'express';
 import * as cors from 'cors';
 import {RegistryClient} from '@giteshk-org/apigeeregistry';

--- a/containers/registry-mock-server/openapi/src/index.ts
+++ b/containers/registry-mock-server/openapi/src/index.ts
@@ -1,24 +1,8 @@
-/**
- * Copyright 2022 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 import * as express from 'express';
 import * as cors from 'cors';
 import {RegistryClient} from '@giteshk-org/apigeeregistry';
 import {ClientOptions} from 'google-gax';
-import {credentials} from '@grpc/grpc-js';
+import * as grpc from '@grpc/grpc-js';
 const Yaml = require('js-yaml');
 
 import {IHttpOperation} from '@stoplight/types';
@@ -40,7 +24,7 @@ const client_options = <ClientOptions>{};
 
 if (process.env.APG_REGISTRY_INSECURE) {
   if (process.env.APG_REGISTRY_INSECURE === '1') {
-    client_options.sslCreds = credentials.createInsecure();
+    client_options.sslCreds = grpc.credentials.createInsecure();
   }
 }
 
@@ -67,13 +51,6 @@ function _sendError(err: Error, res: Response) {
 
 /**
  * Process the mock request
- * This method will fetch the spec contents from Registry
- * and pass the spec to the Prism Library.
- *
- * Prism Library will generate responses based on the contents of the spec.
- * * Prism Documentation details of how responses are generated:
- * https://meta.stoplight.io/docs/prism/ZG9jOjk1-http-mocking#response-examples
- *
  * @param req
  * @param res
  */

--- a/containers/registry-mock-server/openapi/src/index.ts
+++ b/containers/registry-mock-server/openapi/src/index.ts
@@ -18,7 +18,7 @@ import * as express from 'express';
 import * as cors from 'cors';
 import {RegistryClient} from '@giteshk-org/apigeeregistry';
 import {ClientOptions} from 'google-gax';
-import * as grpc from '@grpc/grpc-js';
+import {credentials} from '@grpc/grpc-js';
 const Yaml = require('js-yaml');
 
 import {IHttpOperation} from '@stoplight/types';
@@ -40,7 +40,7 @@ const client_options = <ClientOptions>{};
 
 if (process.env.APG_REGISTRY_INSECURE) {
   if (process.env.APG_REGISTRY_INSECURE === '1') {
-    client_options.sslCreds = grpc.credentials.createInsecure();
+    client_options.sslCreds = credentials.createInsecure();
   }
 }
 

--- a/containers/registry-mock-server/openapi/src/index.ts
+++ b/containers/registry-mock-server/openapi/src/index.ts
@@ -67,6 +67,13 @@ function _sendError(err: Error, res: Response) {
 
 /**
  * Process the mock request
+ * This method will fetch the spec contents from Registry
+ * and pass the spec to the Prism Library.
+ *
+ * Prism Library will generate responses based on the contents of the spec.
+ * * Prism Documentation details of how responses are generated:
+ * https://meta.stoplight.io/docs/prism/ZG9jOjk1-http-mocking#response-examples
+ *
  * @param req
  * @param res
  */

--- a/containers/registry-spec-renderer/README.md
+++ b/containers/registry-spec-renderer/README.md
@@ -19,11 +19,11 @@ gcloud compute firewall-rules create registry-renderer-service-fw \
     --rules tcp:80
 
 
-gcloud compute instances create-with-container registry-renderer-instance1 \
+gcloud compute instances create-with-container registry-renderer-instance \
 	--machine-type=e2-micro  --tags=registry-spec-renderer,http-server \
 	--scopes=https://www.googleapis.com/auth/cloud-platform \
 	--restart-on-failure --service-account=registry-reader@$REGISTRY_PROJECT_IDENTIFIER.iam.gserviceaccount.com\
-    --container-image ghcr.io/apigee/registry-spec-renderer:latest
+    --container-image ghcr.io/apigee/registry-spec-renderer:main
 ```
 
 ### To run this against the opensource version of Apigee Registry on GKE you will need to:  

--- a/containers/registry-spec-renderer/README.md
+++ b/containers/registry-spec-renderer/README.md
@@ -4,12 +4,12 @@ This container allows for rendering of specs from the API Registry.
 ### To run this service on a GCE instance run the following command:
 ```
 export REGISTRY_PROJECT_IDENTIFIER=$(gcloud config list --format 'value(core.project)')
-gcloud iam service-accounts create registry-reader \
+gcloud iam service-accounts create registry-viewer \
     --description="Registry Reader" \
     --display-name="Registry Reader"
 
 gcloud projects add-iam-policy-binding $REGISTRY_PROJECT_IDENTIFIER \
-    --member="serviceAccount:registry-reader@$REGISTRY_PROJECT_IDENTIFIER.iam.gserviceaccount.com" \
+    --member="serviceAccount:registry-viewer@$REGISTRY_PROJECT_IDENTIFIER.iam.gserviceaccount.com" \
     --role="roles/apigeeregistry.viewer"
 
 gcloud compute firewall-rules create registry-renderer-service-fw \
@@ -22,7 +22,7 @@ gcloud compute firewall-rules create registry-renderer-service-fw \
 gcloud compute instances create-with-container registry-renderer-instance \
 	--machine-type=e2-micro  --tags=registry-spec-renderer,http-server \
 	--scopes=https://www.googleapis.com/auth/cloud-platform \
-	--restart-on-failure --service-account=registry-reader@$REGISTRY_PROJECT_IDENTIFIER.iam.gserviceaccount.com\
+	--restart-on-failure --service-account=registry-viewer@$REGISTRY_PROJECT_IDENTIFIER.iam.gserviceaccount.com\
     --container-image ghcr.io/apigee/registry-spec-renderer:main
 ```
 

--- a/containers/registry-spec-renderer/index.js
+++ b/containers/registry-spec-renderer/index.js
@@ -237,8 +237,8 @@ function addMockAddressForOpenAPI(openAPISpecObj, spec_url, api_url, res) {
   client.listApiDeployments({
     parent: api_url,
     filter: "api_spec_revision == '" + spec_url + "'"
-  }).then(deployments => {
-    if (deployments.length > 0) {
+  }, (err, deployments) => {
+    if (!err && deployments && deployments.length > 0) {
       deployments.forEach(deployment => {
         if (!deployment.endpointUri) {
           return;
@@ -259,14 +259,6 @@ function addMockAddressForOpenAPI(openAPISpecObj, spec_url, api_url, res) {
         }
       })
     }
-    res.json(openAPISpecObj);
-    res.end();
-  }).catch(err => {
-    /**
-     * Ignore error and just return the spec without the additional
-     * deployment information.
-     */
-    console.error(err)
     res.json(openAPISpecObj);
     res.end();
   });

--- a/containers/registry-spec-renderer/index.js
+++ b/containers/registry-spec-renderer/index.js
@@ -17,14 +17,14 @@ const express = require('express')
 const fs = require("fs");
 const handlebars = require("handlebars");
 const {RegistryClient} = require("@giteshk-org/apigeeregistry");
-const grpc = require("@grpc/grpc-js");
+const {credentials} = require("@grpc/grpc-js");
 const jsYaml = require('js-yaml');
 var cors = require('cors')
 
 var client_options = {};
 if (process.env.APG_REGISTRY_INSECURE
     && process.env.APG_REGISTRY_INSECURE == "1") {
-  client_options.sslCreds = grpc.credentials.createInsecure();
+  client_options.sslCreds = credentials.createInsecure();
 }
 
 const MOCK_ENDPOINT_ARTIFACT_NAME = process.env.MOCK_ENDPOINT_ARTIFACT_NAME
@@ -167,7 +167,9 @@ app.all(
       let spec_url = "projects/" + req.params.projectId + "/locations/"
           + req.params.locationId + "/apis/" + req.params.apiId + "/versions/"
           + req.params.versionId + "/specs/" + req.params.specId;
-
+      let version_url = "projects/" + req.params.projectId + "/locations/"
+          + req.params.locationId + "/apis/" + req.params.apiId + "/versions/"
+          + req.params.versionId;
       client.getApiSpecContents(
           {
             name: spec_url

--- a/containers/registry-spec-renderer/index.js
+++ b/containers/registry-spec-renderer/index.js
@@ -19,6 +19,7 @@ const handlebars = require("handlebars");
 const {RegistryClient} = require("@giteshk-org/apigeeregistry");
 const {credentials} = require("@grpc/grpc-js");
 const jsYaml = require('js-yaml');
+const { parseURL } = require("whatwg-url");
 var cors = require('cors')
 
 var client_options = {};
@@ -262,7 +263,10 @@ function addMockAddressForOpenAPI(openAPISpecObj, spec_url, api_url, res) {
       }
       if (openAPISpecObj.swagger && openAPISpecObj.swagger.startsWith("2")
           && !openAPISpecObj.host) {
-        openAPISpecObj.host = deployment.endpointUri;
+        let parsedUrl = parseURL(deployment.endpointUri);
+        openAPISpecObj.host = parsedUrl.host;
+        openAPISpecObj.basePath = "/" + parsedUrl.path.join("/");
+        openAPISpecObj.schemes = [parsedUrl.scheme];
       } else if (openAPISpecObj.openapi &&
           openAPISpecObj.openapi.startsWith("3")) {
         openAPISpecObj = openAPISpecObj || {

--- a/containers/registry-spec-renderer/package.json
+++ b/containers/registry-spec-renderer/package.json
@@ -19,6 +19,7 @@
     "handlebars": "^4.7.7",
     "js-yaml": "^4.1.0",
     "react-dom": "^17.0.2",
-    "swagger-ui-dist": "^4.1.3"
+    "swagger-ui-dist": "^4.1.3",
+    "whatwg-url": "^11.0.0"
   }
 }


### PR DESCRIPTION
For Deployments the mock handler return responses for the spec revision associated with the deployment.
Swagger UI incorporates the Deployments from Registry and re-writes the server variable for OpenAPI 3.0