### PR TITLE
Add yamls for googleapis and include score definitions

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -3,8 +3,39 @@
 Each subdirectory contains a sample project that can be uploaded using the
 `registry` tool, e.g.
 
+## googleapis
+This directory contains yamls which will upload ~60 APIs to the registry, aalong with some project level configurations which will calculate the following artifacts for your specs:
+- vocabulary
+- complexity
+- connformance reports
+- scores
+- scorecards 
+
+* Upload the whole directory using the following command:
+
 ```
 registry apply -f googleapis -R --parent projects/$PROJECT/locations/global
 ```
 
 where `PROJECT` is set to the name of the target project.
+
+Note: Please make sure you are running a registry instance of version `v0.5.3` or higher.
+
+* Wait for 5 to 15 minutes to see the artifacts to show up in the registry. You can use the following commands to list the artifacts
+```
+# Listing vocabulary artifacts
+registry list projects/$PROJECT/locations/global/apis/-/versions/-/specs/-/artifacts/vocabulary
+
+# Listing complexity artifacts
+registry list projects/$PROJECT/locations/global/apis/-/versions/-/specs/-/artifacts/complexity
+
+# Listing conformance artifacts
+registry list projects/$PROJECT/locations/global/apis/-/versions/-/specs/-/artifacts/conformance-apihub-styleguide
+
+# Listing score artifacts
+registry list projects/$PROJECT/locations/global/apis/-/versions/-/specs/-/artifacts/score-lint-errors
+registry list projects/$PROJECT/locations/global/apis/-/versions/-/specs/-/artifacts/score-lint-warnings
+
+# Listing scorecard artifacts
+registry list projects/$PROJECT/locations/global/apis/-/versions/-/specs/-/artifacts/scorecard-lint-summary
+```

--- a/samples/googleapis/apis/googleapis.com-analyticsadmin.yaml
+++ b/samples/googleapis/apis/googleapis.com-analyticsadmin.yaml
@@ -1,0 +1,18 @@
+apiVersion: apigeeregistry/v1
+kind: API
+metadata:
+  name: googleapis.com-analyticsadmin
+data:
+  displayName: googleapis.com-analyticsadmin
+  description: Google Analytics Admin API
+  versions:
+    - metadata:
+        name: v1alpha
+      data:
+        specs:
+          - metadata:
+              name: openapi.yaml
+            data:
+              filename: openapi.yaml
+              mimeType: application/x.openapi+gzip;version=3
+              sourceURI: https://raw.githubusercontent.com/APIs-guru/openapi-directory/754babf60fe7fae589c43afea8ff31c44cfb48e9/APIs/googleapis.com/analyticsadmin/v1alpha/openapi.yaml

--- a/samples/googleapis/apis/googleapis.com-analyticshub.yaml
+++ b/samples/googleapis/apis/googleapis.com-analyticshub.yaml
@@ -1,10 +1,10 @@
 apiVersion: apigeeregistry/v1
 kind: API
 metadata:
-  name: googleapis.com-firebase
+  name: googleapis.com-analyticshub
 data:
-  displayName: googleapis.com-firebase
-  description: Firebase Management API
+  displayName: googleapis.com-analyticshub
+  description: Analytics Hub API
   versions:
     - metadata:
         name: v1beta1
@@ -15,4 +15,4 @@ data:
             data:
               filename: openapi.yaml
               mimeType: application/x.openapi+gzip;version=3
-              sourceURI: https://raw.githubusercontent.com/APIs-guru/openapi-directory/754babf60fe7fae589c43afea8ff31c44cfb48e9/APIs/googleapis.com/firebase/v1beta1/openapi.yaml
+              sourceURI: https://raw.githubusercontent.com/APIs-guru/openapi-directory/754babf60fe7fae589c43afea8ff31c44cfb48e9/APIs/googleapis.com/analyticshub/v1beta1/openapi.yaml

--- a/samples/googleapis/apis/googleapis.com-apigateway.yaml
+++ b/samples/googleapis/apis/googleapis.com-apigateway.yaml
@@ -1,13 +1,13 @@
 apiVersion: apigeeregistry/v1
 kind: API
 metadata:
-  name: googleapis.com-translate
+  name: googleapis.com-apigateway
 data:
-  displayName: googleapis.com-translate
-  description: Cloud Translation API
+  displayName: googleapis.com-apigateway
+  description: API Gateway API
   versions:
     - metadata:
-        name: v2
+        name: v1
       data:
         specs:
           - metadata:
@@ -15,9 +15,9 @@ data:
             data:
               filename: openapi.yaml
               mimeType: application/x.openapi+gzip;version=3
-              sourceURI: https://raw.githubusercontent.com/APIs-guru/openapi-directory/754babf60fe7fae589c43afea8ff31c44cfb48e9/APIs/googleapis.com/translate/v2/openapi.yaml
+              sourceURI: https://raw.githubusercontent.com/APIs-guru/openapi-directory/754babf60fe7fae589c43afea8ff31c44cfb48e9/APIs/googleapis.com/apigateway/v1/openapi.yaml
     - metadata:
-        name: v3
+        name: v1alpha2
       data:
         specs:
           - metadata:
@@ -25,9 +25,9 @@ data:
             data:
               filename: openapi.yaml
               mimeType: application/x.openapi+gzip;version=3
-              sourceURI: https://raw.githubusercontent.com/APIs-guru/openapi-directory/754babf60fe7fae589c43afea8ff31c44cfb48e9/APIs/googleapis.com/translate/v3/openapi.yaml
+              sourceURI: https://raw.githubusercontent.com/APIs-guru/openapi-directory/754babf60fe7fae589c43afea8ff31c44cfb48e9/APIs/googleapis.com/apigateway/v1alpha2/openapi.yaml
     - metadata:
-        name: v3beta1
+        name: v1beta
       data:
         specs:
           - metadata:
@@ -35,4 +35,4 @@ data:
             data:
               filename: openapi.yaml
               mimeType: application/x.openapi+gzip;version=3
-              sourceURI: https://raw.githubusercontent.com/APIs-guru/openapi-directory/754babf60fe7fae589c43afea8ff31c44cfb48e9/APIs/googleapis.com/translate/v3beta1/openapi.yaml
+              sourceURI: https://raw.githubusercontent.com/APIs-guru/openapi-directory/754babf60fe7fae589c43afea8ff31c44cfb48e9/APIs/googleapis.com/apigateway/v1beta/openapi.yaml

--- a/samples/googleapis/apis/googleapis.com-apigee.yaml
+++ b/samples/googleapis/apis/googleapis.com-apigee.yaml
@@ -1,10 +1,10 @@
 apiVersion: apigeeregistry/v1
 kind: API
 metadata:
-  name: googleapis.com-books
+  name: googleapis.com-apigee
 data:
-  displayName: googleapis.com-books
-  description: Books API
+  displayName: googleapis.com-apigee
+  description: Apigee API
   versions:
     - metadata:
         name: v1
@@ -15,4 +15,4 @@ data:
             data:
               filename: openapi.yaml
               mimeType: application/x.openapi+gzip;version=3
-              sourceURI: https://raw.githubusercontent.com/APIs-guru/openapi-directory/754babf60fe7fae589c43afea8ff31c44cfb48e9/APIs/googleapis.com/books/v1/openapi.yaml
+              sourceURI: https://raw.githubusercontent.com/APIs-guru/openapi-directory/754babf60fe7fae589c43afea8ff31c44cfb48e9/APIs/googleapis.com/apigee/v1/openapi.yaml

--- a/samples/googleapis/apis/googleapis.com-apigeeregistry.yaml
+++ b/samples/googleapis/apis/googleapis.com-apigeeregistry.yaml
@@ -1,10 +1,10 @@
 apiVersion: apigeeregistry/v1
 kind: API
 metadata:
-  name: googleapis.com-books
+  name: googleapis.com-apigeeregistry
 data:
-  displayName: googleapis.com-books
-  description: Books API
+  displayName: googleapis.com-apigeeregistry
+  description: Apigee Registry API
   versions:
     - metadata:
         name: v1
@@ -15,4 +15,4 @@ data:
             data:
               filename: openapi.yaml
               mimeType: application/x.openapi+gzip;version=3
-              sourceURI: https://raw.githubusercontent.com/APIs-guru/openapi-directory/754babf60fe7fae589c43afea8ff31c44cfb48e9/APIs/googleapis.com/books/v1/openapi.yaml
+              sourceURI: https://raw.githubusercontent.com/APIs-guru/openapi-directory/754babf60fe7fae589c43afea8ff31c44cfb48e9/APIs/googleapis.com/apigeeregistry/v1/openapi.yaml

--- a/samples/googleapis/apis/googleapis.com-area120tables.yaml
+++ b/samples/googleapis/apis/googleapis.com-area120tables.yaml
@@ -1,0 +1,18 @@
+apiVersion: apigeeregistry/v1
+kind: API
+metadata:
+  name: googleapis.com-area120tables
+data:
+  displayName: googleapis.com-area120tables
+  description: Area120 Tables API
+  versions:
+    - metadata:
+        name: v1alpha1
+      data:
+        specs:
+          - metadata:
+              name: openapi.yaml
+            data:
+              filename: openapi.yaml
+              mimeType: application/x.openapi+gzip;version=3
+              sourceURI: https://raw.githubusercontent.com/APIs-guru/openapi-directory/754babf60fe7fae589c43afea8ff31c44cfb48e9/APIs/googleapis.com/area120tables/v1alpha1/openapi.yaml

--- a/samples/googleapis/apis/googleapis.com-assuredworkloads.yaml
+++ b/samples/googleapis/apis/googleapis.com-assuredworkloads.yaml
@@ -1,0 +1,18 @@
+apiVersion: apigeeregistry/v1
+kind: API
+metadata:
+  name: googleapis.com-assuredworkloads
+data:
+  displayName: googleapis.com-assuredworkloads
+  description: Assured Workloads API
+  versions:
+    - metadata:
+        name: v1
+      data:
+        specs:
+          - metadata:
+              name: openapi.yaml
+            data:
+              filename: openapi.yaml
+              mimeType: application/x.openapi+gzip;version=3
+              sourceURI: https://raw.githubusercontent.com/APIs-guru/openapi-directory/754babf60fe7fae589c43afea8ff31c44cfb48e9/APIs/googleapis.com/assuredworkloads/v1/openapi.yaml

--- a/samples/googleapis/apis/googleapis.com-beyondcorp.yaml
+++ b/samples/googleapis/apis/googleapis.com-beyondcorp.yaml
@@ -1,0 +1,18 @@
+apiVersion: apigeeregistry/v1
+kind: API
+metadata:
+  name: googleapis.com-beyondcorp
+data:
+  displayName: googleapis.com-beyondcorp
+  description: BeyondCorp API
+  versions:
+    - metadata:
+        name: v1alpha
+      data:
+        specs:
+          - metadata:
+              name: openapi.yaml
+            data:
+              filename: openapi.yaml
+              mimeType: application/x.openapi+gzip;version=3
+              sourceURI: https://raw.githubusercontent.com/APIs-guru/openapi-directory/754babf60fe7fae589c43afea8ff31c44cfb48e9/APIs/googleapis.com/beyondcorp/v1alpha/openapi.yaml

--- a/samples/googleapis/apis/googleapis.com-certificatemanager.yaml
+++ b/samples/googleapis/apis/googleapis.com-certificatemanager.yaml
@@ -1,0 +1,18 @@
+apiVersion: apigeeregistry/v1
+kind: API
+metadata:
+  name: googleapis.com-certificatemanager
+data:
+  displayName: googleapis.com-certificatemanager
+  description: Certificate Manager API
+  versions:
+    - metadata:
+        name: v1
+      data:
+        specs:
+          - metadata:
+              name: openapi.yaml
+            data:
+              filename: openapi.yaml
+              mimeType: application/x.openapi+gzip;version=3
+              sourceURI: https://raw.githubusercontent.com/APIs-guru/openapi-directory/754babf60fe7fae589c43afea8ff31c44cfb48e9/APIs/googleapis.com/certificatemanager/v1/openapi.yaml

--- a/samples/googleapis/apis/googleapis.com-clouddeploy.yaml
+++ b/samples/googleapis/apis/googleapis.com-clouddeploy.yaml
@@ -1,10 +1,10 @@
 apiVersion: apigeeregistry/v1
 kind: API
 metadata:
-  name: googleapis.com-books
+  name: googleapis.com-clouddeploy
 data:
-  displayName: googleapis.com-books
-  description: Books API
+  displayName: googleapis.com-clouddeploy
+  description: Google Cloud Deploy API
   versions:
     - metadata:
         name: v1
@@ -15,4 +15,4 @@ data:
             data:
               filename: openapi.yaml
               mimeType: application/x.openapi+gzip;version=3
-              sourceURI: https://raw.githubusercontent.com/APIs-guru/openapi-directory/754babf60fe7fae589c43afea8ff31c44cfb48e9/APIs/googleapis.com/books/v1/openapi.yaml
+              sourceURI: https://raw.githubusercontent.com/APIs-guru/openapi-directory/754babf60fe7fae589c43afea8ff31c44cfb48e9/APIs/googleapis.com/clouddeploy/v1/openapi.yaml

--- a/samples/googleapis/apis/googleapis.com-clouderrorreporting.yaml
+++ b/samples/googleapis/apis/googleapis.com-clouderrorreporting.yaml
@@ -1,0 +1,18 @@
+apiVersion: apigeeregistry/v1
+kind: API
+metadata:
+  name: googleapis.com-clouderrorreporting
+data:
+  displayName: googleapis.com-clouderrorreporting
+  description: Error Reporting API
+  versions:
+    - metadata:
+        name: v1beta1
+      data:
+        specs:
+          - metadata:
+              name: openapi.yaml
+            data:
+              filename: openapi.yaml
+              mimeType: application/x.openapi+gzip;version=3
+              sourceURI: https://raw.githubusercontent.com/APIs-guru/openapi-directory/754babf60fe7fae589c43afea8ff31c44cfb48e9/APIs/googleapis.com/clouderrorreporting/v1beta1/openapi.yaml

--- a/samples/googleapis/apis/googleapis.com-cloudfunctions.yaml
+++ b/samples/googleapis/apis/googleapis.com-cloudfunctions.yaml
@@ -1,0 +1,48 @@
+apiVersion: apigeeregistry/v1
+kind: API
+metadata:
+  name: googleapis.com-cloudfunctions
+data:
+  displayName: googleapis.com-cloudfunctions
+  description: Cloud Functions API
+  versions:
+    - metadata:
+        name: v1
+      data:
+        specs:
+          - metadata:
+              name: openapi.yaml
+            data:
+              filename: openapi.yaml
+              mimeType: application/x.openapi+gzip;version=3
+              sourceURI: https://raw.githubusercontent.com/APIs-guru/openapi-directory/754babf60fe7fae589c43afea8ff31c44cfb48e9/APIs/googleapis.com/cloudfunctions/v1/openapi.yaml
+    - metadata:
+        name: v2
+      data:
+        specs:
+          - metadata:
+              name: openapi.yaml
+            data:
+              filename: openapi.yaml
+              mimeType: application/x.openapi+gzip;version=3
+              sourceURI: https://raw.githubusercontent.com/APIs-guru/openapi-directory/754babf60fe7fae589c43afea8ff31c44cfb48e9/APIs/googleapis.com/cloudfunctions/v2/openapi.yaml
+    - metadata:
+        name: v2alpha
+      data:
+        specs:
+          - metadata:
+              name: openapi.yaml
+            data:
+              filename: openapi.yaml
+              mimeType: application/x.openapi+gzip;version=3
+              sourceURI: https://raw.githubusercontent.com/APIs-guru/openapi-directory/754babf60fe7fae589c43afea8ff31c44cfb48e9/APIs/googleapis.com/cloudfunctions/v2alpha/openapi.yaml
+    - metadata:
+        name: v2beta
+      data:
+        specs:
+          - metadata:
+              name: openapi.yaml
+            data:
+              filename: openapi.yaml
+              mimeType: application/x.openapi+gzip;version=3
+              sourceURI: https://raw.githubusercontent.com/APIs-guru/openapi-directory/754babf60fe7fae589c43afea8ff31c44cfb48e9/APIs/googleapis.com/cloudfunctions/v2beta/openapi.yaml

--- a/samples/googleapis/apis/googleapis.com-containeranalysis.yaml
+++ b/samples/googleapis/apis/googleapis.com-containeranalysis.yaml
@@ -1,0 +1,38 @@
+apiVersion: apigeeregistry/v1
+kind: API
+metadata:
+  name: googleapis.com-containeranalysis
+data:
+  displayName: googleapis.com-containeranalysis
+  description: Container Analysis API
+  versions:
+    - metadata:
+        name: v1
+      data:
+        specs:
+          - metadata:
+              name: openapi.yaml
+            data:
+              filename: openapi.yaml
+              mimeType: application/x.openapi+gzip;version=3
+              sourceURI: https://raw.githubusercontent.com/APIs-guru/openapi-directory/754babf60fe7fae589c43afea8ff31c44cfb48e9/APIs/googleapis.com/containeranalysis/v1/openapi.yaml
+    - metadata:
+        name: v1alpha1
+      data:
+        specs:
+          - metadata:
+              name: openapi.yaml
+            data:
+              filename: openapi.yaml
+              mimeType: application/x.openapi+gzip;version=3
+              sourceURI: https://raw.githubusercontent.com/APIs-guru/openapi-directory/754babf60fe7fae589c43afea8ff31c44cfb48e9/APIs/googleapis.com/containeranalysis/v1alpha1/openapi.yaml
+    - metadata:
+        name: v1beta1
+      data:
+        specs:
+          - metadata:
+              name: openapi.yaml
+            data:
+              filename: openapi.yaml
+              mimeType: application/x.openapi+gzip;version=3
+              sourceURI: https://raw.githubusercontent.com/APIs-guru/openapi-directory/754babf60fe7fae589c43afea8ff31c44cfb48e9/APIs/googleapis.com/containeranalysis/v1beta1/openapi.yaml

--- a/samples/googleapis/apis/googleapis.com-datapipelines.yaml
+++ b/samples/googleapis/apis/googleapis.com-datapipelines.yaml
@@ -1,10 +1,10 @@
 apiVersion: apigeeregistry/v1
 kind: API
 metadata:
-  name: googleapis.com-books
+  name: googleapis.com-datapipelines
 data:
-  displayName: googleapis.com-books
-  description: Books API
+  displayName: googleapis.com-datapipelines
+  description: Data pipelines API
   versions:
     - metadata:
         name: v1
@@ -15,4 +15,4 @@ data:
             data:
               filename: openapi.yaml
               mimeType: application/x.openapi+gzip;version=3
-              sourceURI: https://raw.githubusercontent.com/APIs-guru/openapi-directory/754babf60fe7fae589c43afea8ff31c44cfb48e9/APIs/googleapis.com/books/v1/openapi.yaml
+              sourceURI: https://raw.githubusercontent.com/APIs-guru/openapi-directory/754babf60fe7fae589c43afea8ff31c44cfb48e9/APIs/googleapis.com/datapipelines/v1/openapi.yaml

--- a/samples/googleapis/apis/googleapis.com-datastream.yaml
+++ b/samples/googleapis/apis/googleapis.com-datastream.yaml
@@ -1,0 +1,28 @@
+apiVersion: apigeeregistry/v1
+kind: API
+metadata:
+  name: googleapis.com-datastream
+data:
+  displayName: googleapis.com-datastream
+  description: Datastream API
+  versions:
+    - metadata:
+        name: v1
+      data:
+        specs:
+          - metadata:
+              name: openapi.yaml
+            data:
+              filename: openapi.yaml
+              mimeType: application/x.openapi+gzip;version=3
+              sourceURI: https://raw.githubusercontent.com/APIs-guru/openapi-directory/754babf60fe7fae589c43afea8ff31c44cfb48e9/APIs/googleapis.com/datastream/v1/openapi.yaml
+    - metadata:
+        name: v1alpha1
+      data:
+        specs:
+          - metadata:
+              name: openapi.yaml
+            data:
+              filename: openapi.yaml
+              mimeType: application/x.openapi+gzip;version=3
+              sourceURI: https://raw.githubusercontent.com/APIs-guru/openapi-directory/754babf60fe7fae589c43afea8ff31c44cfb48e9/APIs/googleapis.com/datastream/v1alpha1/openapi.yaml

--- a/samples/googleapis/apis/googleapis.com-essentialcontacts.yaml
+++ b/samples/googleapis/apis/googleapis.com-essentialcontacts.yaml
@@ -1,0 +1,18 @@
+apiVersion: apigeeregistry/v1
+kind: API
+metadata:
+  name: googleapis.com-essentialcontacts
+data:
+  displayName: googleapis.com-essentialcontacts
+  description: Essential Contacts API
+  versions:
+    - metadata:
+        name: v1
+      data:
+        specs:
+          - metadata:
+              name: openapi.yaml
+            data:
+              filename: openapi.yaml
+              mimeType: application/x.openapi+gzip;version=3
+              sourceURI: https://raw.githubusercontent.com/APIs-guru/openapi-directory/754babf60fe7fae589c43afea8ff31c44cfb48e9/APIs/googleapis.com/essentialcontacts/v1/openapi.yaml

--- a/samples/googleapis/apis/googleapis.com-factchecktools.yaml
+++ b/samples/googleapis/apis/googleapis.com-factchecktools.yaml
@@ -1,0 +1,18 @@
+apiVersion: apigeeregistry/v1
+kind: API
+metadata:
+  name: googleapis.com-factchecktools
+data:
+  displayName: googleapis.com-factchecktools
+  description: Fact Check Tools API
+  versions:
+    - metadata:
+        name: v1alpha1
+      data:
+        specs:
+          - metadata:
+              name: openapi.yaml
+            data:
+              filename: openapi.yaml
+              mimeType: application/x.openapi+gzip;version=3
+              sourceURI: https://raw.githubusercontent.com/APIs-guru/openapi-directory/754babf60fe7fae589c43afea8ff31c44cfb48e9/APIs/googleapis.com/factchecktools/v1alpha1/openapi.yaml

--- a/samples/googleapis/apis/googleapis.com-gkehub.yaml
+++ b/samples/googleapis/apis/googleapis.com-gkehub.yaml
@@ -1,0 +1,68 @@
+apiVersion: apigeeregistry/v1
+kind: API
+metadata:
+  name: googleapis.com-gkehub
+data:
+  displayName: googleapis.com-gkehub
+  description: GKE Hub API
+  versions:
+    - metadata:
+        name: v1
+      data:
+        specs:
+          - metadata:
+              name: openapi.yaml
+            data:
+              filename: openapi.yaml
+              mimeType: application/x.openapi+gzip;version=3
+              sourceURI: https://raw.githubusercontent.com/APIs-guru/openapi-directory/754babf60fe7fae589c43afea8ff31c44cfb48e9/APIs/googleapis.com/gkehub/v1/openapi.yaml
+    - metadata:
+        name: v1alpha
+      data:
+        specs:
+          - metadata:
+              name: openapi.yaml
+            data:
+              filename: openapi.yaml
+              mimeType: application/x.openapi+gzip;version=3
+              sourceURI: https://raw.githubusercontent.com/APIs-guru/openapi-directory/754babf60fe7fae589c43afea8ff31c44cfb48e9/APIs/googleapis.com/gkehub/v1alpha/openapi.yaml
+    - metadata:
+        name: v1alpha2
+      data:
+        specs:
+          - metadata:
+              name: openapi.yaml
+            data:
+              filename: openapi.yaml
+              mimeType: application/x.openapi+gzip;version=3
+              sourceURI: https://raw.githubusercontent.com/APIs-guru/openapi-directory/754babf60fe7fae589c43afea8ff31c44cfb48e9/APIs/googleapis.com/gkehub/v1alpha2/openapi.yaml
+    - metadata:
+        name: v1beta
+      data:
+        specs:
+          - metadata:
+              name: openapi.yaml
+            data:
+              filename: openapi.yaml
+              mimeType: application/x.openapi+gzip;version=3
+              sourceURI: https://raw.githubusercontent.com/APIs-guru/openapi-directory/754babf60fe7fae589c43afea8ff31c44cfb48e9/APIs/googleapis.com/gkehub/v1beta/openapi.yaml
+    - metadata:
+        name: v1beta1
+      data:
+        specs:
+          - metadata:
+              name: openapi.yaml
+            data:
+              filename: openapi.yaml
+              mimeType: application/x.openapi+gzip;version=3
+              sourceURI: https://raw.githubusercontent.com/APIs-guru/openapi-directory/754babf60fe7fae589c43afea8ff31c44cfb48e9/APIs/googleapis.com/gkehub/v1beta1/openapi.yaml
+    - metadata:
+        name: v2alpha
+      data:
+        specs:
+          - metadata:
+              name: openapi.yaml
+            data:
+              filename: openapi.yaml
+              mimeType: application/x.openapi+gzip;version=3
+              sourceURI: https://raw.githubusercontent.com/APIs-guru/openapi-directory/754babf60fe7fae589c43afea8ff31c44cfb48e9/APIs/googleapis.com/gkehub/v2alpha/openapi.yaml

--- a/samples/googleapis/apis/googleapis.com-mybusinessqanda.yaml
+++ b/samples/googleapis/apis/googleapis.com-mybusinessqanda.yaml
@@ -1,0 +1,18 @@
+apiVersion: apigeeregistry/v1
+kind: API
+metadata:
+  name: googleapis.com-mybusinessqanda
+data:
+  displayName: googleapis.com-mybusinessqanda
+  description: My Business Q&A API
+  versions:
+    - metadata:
+        name: v1
+      data:
+        specs:
+          - metadata:
+              name: openapi.yaml
+            data:
+              filename: openapi.yaml
+              mimeType: application/x.openapi+gzip;version=3
+              sourceURI: https://raw.githubusercontent.com/APIs-guru/openapi-directory/754babf60fe7fae589c43afea8ff31c44cfb48e9/APIs/googleapis.com/mybusinessqanda/v1/openapi.yaml

--- a/samples/googleapis/apis/googleapis.com-networkservices.yaml
+++ b/samples/googleapis/apis/googleapis.com-networkservices.yaml
@@ -1,0 +1,28 @@
+apiVersion: apigeeregistry/v1
+kind: API
+metadata:
+  name: googleapis.com-networkservices
+data:
+  displayName: googleapis.com-networkservices
+  description: Network Services API
+  versions:
+    - metadata:
+        name: v1
+      data:
+        specs:
+          - metadata:
+              name: openapi.yaml
+            data:
+              filename: openapi.yaml
+              mimeType: application/x.openapi+gzip;version=3
+              sourceURI: https://raw.githubusercontent.com/APIs-guru/openapi-directory/754babf60fe7fae589c43afea8ff31c44cfb48e9/APIs/googleapis.com/networkservices/v1/openapi.yaml
+    - metadata:
+        name: v1beta1
+      data:
+        specs:
+          - metadata:
+              name: openapi.yaml
+            data:
+              filename: openapi.yaml
+              mimeType: application/x.openapi+gzip;version=3
+              sourceURI: https://raw.githubusercontent.com/APIs-guru/openapi-directory/754babf60fe7fae589c43afea8ff31c44cfb48e9/APIs/googleapis.com/networkservices/v1beta1/openapi.yaml

--- a/samples/googleapis/apis/googleapis.com-oauth2.yaml
+++ b/samples/googleapis/apis/googleapis.com-oauth2.yaml
@@ -1,0 +1,28 @@
+apiVersion: apigeeregistry/v1
+kind: API
+metadata:
+  name: googleapis.com-oauth2
+data:
+  displayName: googleapis.com-oauth2
+  description: Google OAuth2 API
+  versions:
+    - metadata:
+        name: v1
+      data:
+        specs:
+          - metadata:
+              name: openapi.yaml
+            data:
+              filename: openapi.yaml
+              mimeType: application/x.openapi+gzip;version=3
+              sourceURI: https://raw.githubusercontent.com/APIs-guru/openapi-directory/754babf60fe7fae589c43afea8ff31c44cfb48e9/APIs/googleapis.com/oauth2/v1/openapi.yaml
+    - metadata:
+        name: v2
+      data:
+        specs:
+          - metadata:
+              name: openapi.yaml
+            data:
+              filename: openapi.yaml
+              mimeType: application/x.openapi+gzip;version=3
+              sourceURI: https://raw.githubusercontent.com/APIs-guru/openapi-directory/754babf60fe7fae589c43afea8ff31c44cfb48e9/APIs/googleapis.com/oauth2/v2/openapi.yaml

--- a/samples/googleapis/apis/googleapis.com-paymentsresellersubscription.yaml
+++ b/samples/googleapis/apis/googleapis.com-paymentsresellersubscription.yaml
@@ -1,0 +1,18 @@
+apiVersion: apigeeregistry/v1
+kind: API
+metadata:
+  name: googleapis.com-paymentsresellersubscription
+data:
+  displayName: googleapis.com-paymentsresellersubscription
+  description: Payments Reseller Subscription API
+  versions:
+    - metadata:
+        name: v1
+      data:
+        specs:
+          - metadata:
+              name: openapi.yaml
+            data:
+              filename: openapi.yaml
+              mimeType: application/x.openapi+gzip;version=3
+              sourceURI: https://raw.githubusercontent.com/APIs-guru/openapi-directory/754babf60fe7fae589c43afea8ff31c44cfb48e9/APIs/googleapis.com/paymentsresellersubscription/v1/openapi.yaml

--- a/samples/googleapis/apis/googleapis.com-playdeveloperreporting.yaml
+++ b/samples/googleapis/apis/googleapis.com-playdeveloperreporting.yaml
@@ -1,0 +1,28 @@
+apiVersion: apigeeregistry/v1
+kind: API
+metadata:
+  name: googleapis.com-playdeveloperreporting
+data:
+  displayName: googleapis.com-playdeveloperreporting
+  description: Google Play Developer Reporting API
+  versions:
+    - metadata:
+        name: v1alpha1
+      data:
+        specs:
+          - metadata:
+              name: openapi.yaml
+            data:
+              filename: openapi.yaml
+              mimeType: application/x.openapi+gzip;version=3
+              sourceURI: https://raw.githubusercontent.com/APIs-guru/openapi-directory/754babf60fe7fae589c43afea8ff31c44cfb48e9/APIs/googleapis.com/playdeveloperreporting/v1alpha1/openapi.yaml
+    - metadata:
+        name: v1beta1
+      data:
+        specs:
+          - metadata:
+              name: openapi.yaml
+            data:
+              filename: openapi.yaml
+              mimeType: application/x.openapi+gzip;version=3
+              sourceURI: https://raw.githubusercontent.com/APIs-guru/openapi-directory/754babf60fe7fae589c43afea8ff31c44cfb48e9/APIs/googleapis.com/playdeveloperreporting/v1beta1/openapi.yaml

--- a/samples/googleapis/apis/googleapis.com-policyanalyzer.yaml
+++ b/samples/googleapis/apis/googleapis.com-policyanalyzer.yaml
@@ -1,0 +1,28 @@
+apiVersion: apigeeregistry/v1
+kind: API
+metadata:
+  name: googleapis.com-policyanalyzer
+data:
+  displayName: googleapis.com-policyanalyzer
+  description: Policy Analyzer API
+  versions:
+    - metadata:
+        name: v1
+      data:
+        specs:
+          - metadata:
+              name: openapi.yaml
+            data:
+              filename: openapi.yaml
+              mimeType: application/x.openapi+gzip;version=3
+              sourceURI: https://raw.githubusercontent.com/APIs-guru/openapi-directory/754babf60fe7fae589c43afea8ff31c44cfb48e9/APIs/googleapis.com/policyanalyzer/v1/openapi.yaml
+    - metadata:
+        name: v1beta1
+      data:
+        specs:
+          - metadata:
+              name: openapi.yaml
+            data:
+              filename: openapi.yaml
+              mimeType: application/x.openapi+gzip;version=3
+              sourceURI: https://raw.githubusercontent.com/APIs-guru/openapi-directory/754babf60fe7fae589c43afea8ff31c44cfb48e9/APIs/googleapis.com/policyanalyzer/v1beta1/openapi.yaml

--- a/samples/googleapis/apis/googleapis.com-policytroubleshooter.yaml
+++ b/samples/googleapis/apis/googleapis.com-policytroubleshooter.yaml
@@ -1,0 +1,28 @@
+apiVersion: apigeeregistry/v1
+kind: API
+metadata:
+  name: googleapis.com-policytroubleshooter
+data:
+  displayName: googleapis.com-policytroubleshooter
+  description: Policy Troubleshooter API
+  versions:
+    - metadata:
+        name: v1
+      data:
+        specs:
+          - metadata:
+              name: openapi.yaml
+            data:
+              filename: openapi.yaml
+              mimeType: application/x.openapi+gzip;version=3
+              sourceURI: https://raw.githubusercontent.com/APIs-guru/openapi-directory/754babf60fe7fae589c43afea8ff31c44cfb48e9/APIs/googleapis.com/policytroubleshooter/v1/openapi.yaml
+    - metadata:
+        name: v1beta
+      data:
+        specs:
+          - metadata:
+              name: openapi.yaml
+            data:
+              filename: openapi.yaml
+              mimeType: application/x.openapi+gzip;version=3
+              sourceURI: https://raw.githubusercontent.com/APIs-guru/openapi-directory/754babf60fe7fae589c43afea8ff31c44cfb48e9/APIs/googleapis.com/policytroubleshooter/v1beta/openapi.yaml

--- a/samples/googleapis/apis/googleapis.com-prod-tt-sasportal.yaml
+++ b/samples/googleapis/apis/googleapis.com-prod-tt-sasportal.yaml
@@ -1,0 +1,18 @@
+apiVersion: apigeeregistry/v1
+kind: API
+metadata:
+  name: googleapis.com-prod-tt-sasportal
+data:
+  displayName: googleapis.com-prod-tt-sasportal
+  description: SAS Portal API (Testing)
+  versions:
+    - metadata:
+        name: v1alpha1
+      data:
+        specs:
+          - metadata:
+              name: openapi.yaml
+            data:
+              filename: openapi.yaml
+              mimeType: application/x.openapi+gzip;version=3
+              sourceURI: https://raw.githubusercontent.com/APIs-guru/openapi-directory/754babf60fe7fae589c43afea8ff31c44cfb48e9/APIs/googleapis.com/prod_tt_sasportal/v1alpha1/openapi.yaml

--- a/samples/googleapis/apis/googleapis.com-proximitybeacon.yaml
+++ b/samples/googleapis/apis/googleapis.com-proximitybeacon.yaml
@@ -1,0 +1,18 @@
+apiVersion: apigeeregistry/v1
+kind: API
+metadata:
+  name: googleapis.com-proximitybeacon
+data:
+  displayName: googleapis.com-proximitybeacon
+  description: Proximity Beacon API
+  versions:
+    - metadata:
+        name: v1beta1
+      data:
+        specs:
+          - metadata:
+              name: openapi.yaml
+            data:
+              filename: openapi.yaml
+              mimeType: application/x.openapi+gzip;version=3
+              sourceURI: https://raw.githubusercontent.com/APIs-guru/openapi-directory/754babf60fe7fae589c43afea8ff31c44cfb48e9/APIs/googleapis.com/proximitybeacon/v1beta1/openapi.yaml

--- a/samples/googleapis/apis/googleapis.com-pubsub.yaml
+++ b/samples/googleapis/apis/googleapis.com-pubsub.yaml
@@ -1,13 +1,13 @@
 apiVersion: apigeeregistry/v1
 kind: API
 metadata:
-  name: googleapis.com-translate
+  name: googleapis.com-pubsub
 data:
-  displayName: googleapis.com-translate
-  description: Cloud Translation API
+  displayName: googleapis.com-pubsub
+  description: Cloud Pub/Sub API
   versions:
     - metadata:
-        name: v2
+        name: v1
       data:
         specs:
           - metadata:
@@ -15,9 +15,9 @@ data:
             data:
               filename: openapi.yaml
               mimeType: application/x.openapi+gzip;version=3
-              sourceURI: https://raw.githubusercontent.com/APIs-guru/openapi-directory/754babf60fe7fae589c43afea8ff31c44cfb48e9/APIs/googleapis.com/translate/v2/openapi.yaml
+              sourceURI: https://raw.githubusercontent.com/APIs-guru/openapi-directory/754babf60fe7fae589c43afea8ff31c44cfb48e9/APIs/googleapis.com/pubsub/v1/openapi.yaml
     - metadata:
-        name: v3
+        name: v1beta1a
       data:
         specs:
           - metadata:
@@ -25,9 +25,9 @@ data:
             data:
               filename: openapi.yaml
               mimeType: application/x.openapi+gzip;version=3
-              sourceURI: https://raw.githubusercontent.com/APIs-guru/openapi-directory/754babf60fe7fae589c43afea8ff31c44cfb48e9/APIs/googleapis.com/translate/v3/openapi.yaml
+              sourceURI: https://raw.githubusercontent.com/APIs-guru/openapi-directory/754babf60fe7fae589c43afea8ff31c44cfb48e9/APIs/googleapis.com/pubsub/v1beta1a/openapi.yaml
     - metadata:
-        name: v3beta1
+        name: v1beta2
       data:
         specs:
           - metadata:
@@ -35,4 +35,4 @@ data:
             data:
               filename: openapi.yaml
               mimeType: application/x.openapi+gzip;version=3
-              sourceURI: https://raw.githubusercontent.com/APIs-guru/openapi-directory/754babf60fe7fae589c43afea8ff31c44cfb48e9/APIs/googleapis.com/translate/v3beta1/openapi.yaml
+              sourceURI: https://raw.githubusercontent.com/APIs-guru/openapi-directory/754babf60fe7fae589c43afea8ff31c44cfb48e9/APIs/googleapis.com/pubsub/v1beta2/openapi.yaml

--- a/samples/googleapis/apis/googleapis.com-pubsublite.yaml
+++ b/samples/googleapis/apis/googleapis.com-pubsublite.yaml
@@ -1,10 +1,10 @@
 apiVersion: apigeeregistry/v1
 kind: API
 metadata:
-  name: googleapis.com-books
+  name: googleapis.com-pubsublite
 data:
-  displayName: googleapis.com-books
-  description: Books API
+  displayName: googleapis.com-pubsublite
+  description: Pub/Sub Lite API
   versions:
     - metadata:
         name: v1
@@ -15,4 +15,4 @@ data:
             data:
               filename: openapi.yaml
               mimeType: application/x.openapi+gzip;version=3
-              sourceURI: https://raw.githubusercontent.com/APIs-guru/openapi-directory/754babf60fe7fae589c43afea8ff31c44cfb48e9/APIs/googleapis.com/books/v1/openapi.yaml
+              sourceURI: https://raw.githubusercontent.com/APIs-guru/openapi-directory/754babf60fe7fae589c43afea8ff31c44cfb48e9/APIs/googleapis.com/pubsublite/v1/openapi.yaml

--- a/samples/googleapis/apis/googleapis.com-recaptchaenterprise.yaml
+++ b/samples/googleapis/apis/googleapis.com-recaptchaenterprise.yaml
@@ -1,0 +1,18 @@
+apiVersion: apigeeregistry/v1
+kind: API
+metadata:
+  name: googleapis.com-recaptchaenterprise
+data:
+  displayName: googleapis.com-recaptchaenterprise
+  description: reCAPTCHA Enterprise API
+  versions:
+    - metadata:
+        name: v1
+      data:
+        specs:
+          - metadata:
+              name: openapi.yaml
+            data:
+              filename: openapi.yaml
+              mimeType: application/x.openapi+gzip;version=3
+              sourceURI: https://raw.githubusercontent.com/APIs-guru/openapi-directory/754babf60fe7fae589c43afea8ff31c44cfb48e9/APIs/googleapis.com/recaptchaenterprise/v1/openapi.yaml

--- a/samples/googleapis/apis/googleapis.com-vision.yaml
+++ b/samples/googleapis/apis/googleapis.com-vision.yaml
@@ -15,7 +15,7 @@ data:
             data:
               filename: openapi.yaml
               mimeType: application/x.openapi+gzip;version=3
-              sourceURI: https://github.com/APIs-guru/openapi-directory/blob/4262544a5067f9df2efa5622cc21890afd6e06be/APIs/googleapis.com/vision/v1/openapi.yaml
+              sourceURI: https://raw.githubusercontent.com/APIs-guru/openapi-directory/754babf60fe7fae589c43afea8ff31c44cfb48e9/APIs/googleapis.com/vision/v1/openapi.yaml
     - metadata:
         name: v1p1beta1
       data:
@@ -25,7 +25,7 @@ data:
             data:
               filename: openapi.yaml
               mimeType: application/x.openapi+gzip;version=3
-              sourceURI: https://github.com/APIs-guru/openapi-directory/blob/4262544a5067f9df2efa5622cc21890afd6e06be/APIs/googleapis.com/vision/v1p1beta1/openapi.yaml
+              sourceURI: https://raw.githubusercontent.com/APIs-guru/openapi-directory/754babf60fe7fae589c43afea8ff31c44cfb48e9/APIs/googleapis.com/vision/v1p1beta1/openapi.yaml
     - metadata:
         name: v1p2beta1
       data:
@@ -35,4 +35,4 @@ data:
             data:
               filename: openapi.yaml
               mimeType: application/x.openapi+gzip;version=3
-              sourceURI: https://github.com/APIs-guru/openapi-directory/blob/4262544a5067f9df2efa5622cc21890afd6e06be/APIs/googleapis.com/vision/v1p2beta1/openapi.yaml
+              sourceURI: https://raw.githubusercontent.com/APIs-guru/openapi-directory/754babf60fe7fae589c43afea8ff31c44cfb48e9/APIs/googleapis.com/vision/v1p2beta1/openapi.yaml

--- a/samples/googleapis/apis/googleapis.com-youtube.yaml
+++ b/samples/googleapis/apis/googleapis.com-youtube.yaml
@@ -15,4 +15,4 @@ data:
             data:
               filename: openapi.yaml
               mimeType: application/x.openapi+gzip;version=3
-              sourceURI: https://github.com/APIs-guru/openapi-directory/blob/4262544a5067f9df2efa5622cc21890afd6e06be/APIs/googleapis.com/youtube/v3/openapi.yaml
+              sourceURI: https://raw.githubusercontent.com/APIs-guru/openapi-directory/754babf60fe7fae589c43afea8ff31c44cfb48e9/APIs/googleapis.com/youtube/v3/openapi.yaml

--- a/samples/googleapis/artifacts/apihub-lint-errors.yaml
+++ b/samples/googleapis/artifacts/apihub-lint-errors.yaml
@@ -1,0 +1,14 @@
+apiVersion: apigeeregistry/v1
+kind: ScoreDefinition
+metadata:
+  name: lint-errors
+data:
+  target_resource:
+    pattern: "apis/-/versions/-/specs/-"
+  score_formula:
+    artifact:
+      pattern: "$resource.spec/artifacts/conformance-apihub-styleguide"
+    score_expression: "has(guidelineReportGroups[2].guidelineReports) ? sum(guidelineReportGroups[2].guidelineReports.map(r, has(r.ruleReportGroups[1].ruleReports) ? size(r.ruleReportGroups[1].ruleReports) : 0)) : 0"
+  integer: 
+    min_value: 0
+    max_value: 100

--- a/samples/googleapis/artifacts/apihub-lint-summary.yaml
+++ b/samples/googleapis/artifacts/apihub-lint-summary.yaml
@@ -1,0 +1,10 @@
+apiVersion: apigeeregistry/v1
+kind: ScoreCardDefinition
+metadata:
+  name: lint-summary
+data:
+  target_resource:
+    pattern: apis/-/versions/-/specs/-
+  score_patterns:
+  - $resource.spec/artifacts/score-lint-errors
+  - $resource.spec/artifacts/score-lint-warnings

--- a/samples/googleapis/artifacts/apihub-lint-warnings.yaml
+++ b/samples/googleapis/artifacts/apihub-lint-warnings.yaml
@@ -1,0 +1,14 @@
+apiVersion: apigeeregistry/v1
+kind: ScoreDefinition
+metadata:
+  name: lint-warnings
+data:
+  target_resource:
+    pattern: "apis/-/versions/-/specs/-"
+  score_formula:
+    artifact:
+      pattern: "$resource.spec/artifacts/conformance-apihub-styleguide"
+    score_expression: "has(guidelineReportGroups[2].guidelineReports) ? sum(guidelineReportGroups[2].guidelineReports.map(r, has(r.ruleReportGroups[2].ruleReports) ? size(r.ruleReportGroups[2].ruleReports) : 0)) : 0"
+  integer: 
+    min_value: 0
+    max_value: 100

--- a/samples/googleapis/artifacts/apihub-manifest.yaml
+++ b/samples/googleapis/artifacts/apihub-manifest.yaml
@@ -6,36 +6,18 @@ data:
   displayName: ""
   description: ""
   generatedResources:
-    - pattern: apis/-/versions/-/specs/-/artifacts/lint-spectral
-      filter: ""
-      receipt: false
-      dependencies:
-        - pattern: $resource.spec
-          filter: mime_type.contains('openapi')
-      action: registry compute lint $resource.spec --linter spectral
-    - pattern: apis/-/versions/-/specs/-/artifacts/lintstats-spectral
-      filter: ""
-      receipt: false
-      dependencies:
-        - pattern: $resource.spec/artifacts/lint-spectral
-          filter: ""
-        - pattern: $resource.spec/artifacts/complexity
-          filter: ""
-      action: registry compute lintstats $resource.spec --linter spectral
-    - pattern: apis/-/versions/-/specs/-/artifacts/vocabulary
-      filter: ""
-      receipt: false
-      dependencies:
-        - pattern: $resource.spec
-          filter: ""
-      action: registry compute vocabulary $resource.spec
     - pattern: apis/-/versions/-/specs/-/artifacts/complexity
       filter: ""
-      receipt: false
       dependencies:
         - pattern: $resource.spec
           filter: ""
       action: registry compute complexity $resource.spec
+    - pattern: apis/-/versions/-/specs/-/artifacts/vocabulary
+      filter: ""
+      dependencies:
+        - pattern: $resource.spec
+          filter: ""
+      action: registry compute vocabulary $resource.spec
     - pattern: apis/-/versions/-/specs/-/artifacts/conformance-receipt
       filter: ""
       receipt: true
@@ -45,3 +27,13 @@ data:
         - pattern: artifacts/apihub-styleguide
           filter: ""
       action: registry compute conformance $resource.spec
+    - pattern: apis/-/versions/-/specs/-/artifacts/score-receipt
+      filter: ""
+      receipt: true
+      refresh: 300s
+      action: registry compute score $resource.spec
+    - pattern: apis/-/versions/-/specs/-/artifacts/scorecard-receipt
+      filter: ""
+      receipt: true
+      refresh: 300s
+      action: registry compute scorecard $resource.spec

--- a/samples/googleapis/artifacts/apihub-styleguide.yaml
+++ b/samples/googleapis/artifacts/apihub-styleguide.yaml
@@ -71,7 +71,7 @@ data:
           linterRulename: operation-parameters
           severity: WARNING
           docUri: https://meta.stoplight.io/docs/spectral/ZG9jOjExNw-open-api-rules#operation-parameters
-      status: ACTIVE
+      state: ACTIVE
     - id: Info
       displayName: Govern properties of Info
       description: ""
@@ -100,7 +100,7 @@ data:
           linterRulename: info-license
           severity: WARNING
           docUri: https://meta.stoplight.io/docs/spectral/ZG9jOjExNw-open-api-rules#info-license
-      status: ACTIVE
+      state: ACTIVE
     - id: Markdown
       displayName: Govern properties of Markdown
       description: ""
@@ -121,7 +121,7 @@ data:
           linterRulename: no-script-tags-in-markdown
           severity: ERROR
           docUri: https://meta.stoplight.io/docs/spectral/ZG9jOjExNw-open-api-rules#no-script-tags-in-markdown
-      status: ACTIVE
+      state: ACTIVE
     - id: Path
       displayName: Govern properties of Paths
       description: ""
@@ -152,7 +152,7 @@ data:
           linterRulename: path-declarations-must-exist
           severity: WARNING
           docUri: https://meta.stoplight.io/docs/spectral/ZG9jOjExNw-open-api-rules#path-declarations-must-exist
-      status: ACTIVE
+      state: ACTIVE
   linters:
     - name: spectral
       uri: https://github.com/stoplightio/spectral


### PR DESCRIPTION
This PR doesn't contain all the yamls for googleapis, some selected ones which can generate interesting results for conformance reports and scores.

We need to reduce the number of parallel jobs in the controller for the server to be able to handle all the requests from the controller when we upload all 200 of googleapis. Until then, this example works pretty well to demonstrate the scoring functionality.  