### PR TITLE
Add more examples of score definitions

### DIFF
--- a/samples/googleapis/artifacts/apihub-lint-error-percentage.yaml
+++ b/samples/googleapis/artifacts/apihub-lint-error-percentage.yaml
@@ -1,0 +1,36 @@
+apiVersion: apigeeregistry/v1
+kind: ScoreDefinition
+metadata:
+  name: lint-error-percentage
+data:
+  display_name: "Lint Error Percentage"
+  description: "Percentage of lint errors found"
+  uri: "https://meta.stoplight.io/docs/spectral/4dec24461f3af-open-api-rules"
+  uri_display_name: "Spectral rules"
+  target_resource:
+    pattern: "apis/-/versions/-/specs/-"
+  rollup_formula:
+    score_formulas:
+    - artifact:
+        pattern: "$resource.spec/artifacts/conformance-apihub-styleguide"
+      score_expression: "has(guidelineReportGroups[2].guidelineReports) ? sum(guidelineReportGroups[2].guidelineReports.map(r, has(r.ruleReportGroups[1].ruleReports) ? size(r.ruleReportGroups[1].ruleReports) : 0)) : 0"
+      reference_id: "num_errors"
+    - artifact:
+        pattern: "$resource.spec/artifacts/complexity"
+      score_expression: "getCount + postCount + deleteCount"
+      reference_id: "num_operations"
+    rollup_expression: "num_operations > 0.0 ? double(num_errors)/double(num_operations)*100.0 : 0"
+  percent:
+    thresholds: 
+    - severity: ALERT
+      range:
+        min: 20
+        max: 100
+    - severity: WARNING
+      range:
+        min: 10
+        max: 19
+    - severity: OK
+      range:
+        min: 0
+        max: 9

--- a/samples/googleapis/artifacts/apihub-lint-errors-exist.yaml
+++ b/samples/googleapis/artifacts/apihub-lint-errors-exist.yaml
@@ -1,0 +1,23 @@
+apiVersion: apigeeregistry/v1
+kind: ScoreDefinition
+metadata:
+  name: lint-errors-exist
+data:
+  display_name: "Lint Errors Exist"
+  description: "Keeps track if there are lint errors present or not"
+  uri: "https://meta.stoplight.io/docs/spectral/4dec24461f3af-open-api-rules"
+  uri_display_name: "Spectral rules"
+  target_resource:
+    pattern: "apis/-/versions/-/specs/-"
+  score_formula:
+    artifact:
+      pattern: "$resource.spec/artifacts/conformance-apihub-styleguide"
+    score_expression: "has(guidelineReportGroups[2].guidelineReports) ? sum(guidelineReportGroups[2].guidelineReports.map(r, has(r.ruleReportGroups[1].ruleReports) ? size(r.ruleReportGroups[1].ruleReports) : 0)) > 0 : false"
+  boolean:
+    display_true: "Yes"
+    display_false: "No"
+    thresholds:
+      - severity: WARNING
+        value: true
+      - severity: OK
+        value: false

--- a/samples/googleapis/artifacts/apihub-lint-errors.yaml
+++ b/samples/googleapis/artifacts/apihub-lint-errors.yaml
@@ -5,6 +5,8 @@ metadata:
 data:
   display_name: "Lint Errors"
   description: "Number of lint errors found in conformance report"
+  uri: "https://meta.stoplight.io/docs/spectral/4dec24461f3af-open-api-rules"
+  uri_display_name: "Spectral rules"
   target_resource:
     pattern: "apis/-/versions/-/specs/-"
   score_formula:

--- a/samples/googleapis/artifacts/apihub-lint-summary.yaml
+++ b/samples/googleapis/artifacts/apihub-lint-summary.yaml
@@ -10,3 +10,5 @@ data:
   score_patterns:
   - $resource.spec/artifacts/score-lint-errors
   - $resource.spec/artifacts/score-lint-warnings
+  - $resource.spec/artifacts/score-lint-error-percentage
+  - $resource.spec/artifacts/score-lint-errors-exist

--- a/samples/googleapis/artifacts/apihub-lint-warnings.yaml
+++ b/samples/googleapis/artifacts/apihub-lint-warnings.yaml
@@ -5,6 +5,8 @@ metadata:
 data:
   display_name: "Lint Warnings"
   description: "Number of lint warnings found in conformance report"
+  uri: "https://meta.stoplight.io/docs/spectral/4dec24461f3af-open-api-rules"
+  uri_display_name: "Spectral rules"
   target_resource:
     pattern: "apis/-/versions/-/specs/-"
   score_formula:


### PR DESCRIPTION
Created more demo examples for:
- percentage and boolean types (`lint-error-percentage` and `lint-errors-exist`)
- `lint-error-percentage` also makes use of rollup_formula
- set thresholds in percentage and boolean types to demonstrate the feature