### PR TITLE
Update registry to v0.5.4

### DIFF
--- a/cmd/registry-experimental/cmd/compute/descriptor.go
+++ b/cmd/registry-experimental/cmd/compute/descriptor.go
@@ -19,8 +19,8 @@ import (
 	"fmt"
 
 	"github.com/apigee/registry/cmd/registry/core"
-	"github.com/apigee/registry/connection"
 	"github.com/apigee/registry/log"
+	"github.com/apigee/registry/pkg/connection"
 	"github.com/apigee/registry/rpc"
 	"github.com/apigee/registry/server/registry/names"
 	"github.com/spf13/cobra"
@@ -52,11 +52,12 @@ func descriptorCommand(ctx context.Context) *cobra.Command {
 			// Generate tasks.
 			name := args[0]
 			if spec, err := names.ParseSpec(name); err == nil {
-				err = core.ListSpecs(ctx, client, spec, filter, func(spec *rpc.ApiSpec) {
+				err = core.ListSpecs(ctx, client, spec, filter, func(spec *rpc.ApiSpec) error {
 					taskQueue <- &computeDescriptorTask{
 						client:   client,
 						specName: spec.Name,
 					}
+					return nil
 				})
 				if err != nil {
 					log.FromContext(ctx).WithError(err).Fatal("Failed to list specs")
@@ -67,7 +68,7 @@ func descriptorCommand(ctx context.Context) *cobra.Command {
 }
 
 type computeDescriptorTask struct {
-	client   connection.Client
+	client   connection.RegistryClient
 	specName string
 }
 

--- a/cmd/registry-experimental/cmd/compute/index.go
+++ b/cmd/registry-experimental/cmd/compute/index.go
@@ -19,8 +19,8 @@ import (
 	"fmt"
 
 	"github.com/apigee/registry/cmd/registry/core"
-	"github.com/apigee/registry/connection"
 	"github.com/apigee/registry/log"
+	"github.com/apigee/registry/pkg/connection"
 	"github.com/apigee/registry/rpc"
 	"github.com/apigee/registry/server/registry/names"
 	"github.com/spf13/cobra"
@@ -49,11 +49,12 @@ func indexCommand(ctx context.Context) *cobra.Command {
 			name := args[0]
 			if spec, err := names.ParseSpec(name); err == nil {
 				// Iterate through a collection of specs and summarize each.
-				err = core.ListSpecs(ctx, client, spec, filter, func(spec *rpc.ApiSpec) {
+				err = core.ListSpecs(ctx, client, spec, filter, func(spec *rpc.ApiSpec) error {
 					taskQueue <- &computeIndexTask{
 						client:   client,
 						specName: spec.Name,
 					}
+					return nil
 				})
 				if err != nil {
 					log.FromContext(ctx).WithError(err).Fatal("Failed to list specs")
@@ -64,7 +65,7 @@ func indexCommand(ctx context.Context) *cobra.Command {
 }
 
 type computeIndexTask struct {
-	client   connection.Client
+	client   connection.RegistryClient
 	specName string
 }
 

--- a/cmd/registry-experimental/cmd/compute/search-index.go
+++ b/cmd/registry-experimental/cmd/compute/search-index.go
@@ -20,8 +20,8 @@ import (
 	"sync"
 
 	"github.com/apigee/registry/cmd/registry/core"
-	"github.com/apigee/registry/connection"
 	"github.com/apigee/registry/log"
+	"github.com/apigee/registry/pkg/connection"
 	"github.com/apigee/registry/rpc"
 	"github.com/apigee/registry/server/registry/names"
 	"github.com/blevesearch/bleve"
@@ -56,11 +56,12 @@ func searchIndexCommand(ctx context.Context) *cobra.Command {
 			// Generate tasks.
 			name := args[0]
 			if spec, err := names.ParseSpec(name); err == nil {
-				err = core.ListSpecs(ctx, client, spec, filter, func(spec *rpc.ApiSpec) {
+				err = core.ListSpecs(ctx, client, spec, filter, func(spec *rpc.ApiSpec) error {
 					taskQueue <- &indexSpecTask{
 						client:   client,
 						specName: spec.Name,
 					}
+					return nil
 				})
 				if err != nil {
 					log.FromContext(ctx).WithError(err).Fatal("Failed to list specs")
@@ -73,7 +74,7 @@ func searchIndexCommand(ctx context.Context) *cobra.Command {
 }
 
 type indexSpecTask struct {
-	client   connection.Client
+	client   connection.RegistryClient
 	specName string
 }
 

--- a/cmd/registry-experimental/cmd/wipeout/wipeout.go
+++ b/cmd/registry-experimental/cmd/wipeout/wipeout.go
@@ -18,8 +18,8 @@ import (
 	"context"
 
 	"github.com/apigee/registry/cmd/registry/core"
-	"github.com/apigee/registry/connection"
 	"github.com/apigee/registry/log"
+	"github.com/apigee/registry/pkg/connection"
 	"github.com/apigee/registry/rpc"
 	"github.com/spf13/cobra"
 )
@@ -62,7 +62,7 @@ const (
 )
 
 type deleteResourceTask struct {
-	client connection.Client
+	client connection.RegistryClient
 	name   string
 	kind   ResourceKind
 }
@@ -98,7 +98,7 @@ func (task *deleteResourceTask) Run(ctx context.Context) error {
 	return nil
 }
 
-func wipeoutProject(ctx context.Context, registryClient connection.Client, taskQueue chan<- core.Task, project string) {
+func wipeoutProject(ctx context.Context, registryClient connection.RegistryClient, taskQueue chan<- core.Task, project string) {
 	wipeoutArtifacts(ctx, registryClient, taskQueue, project+"/apis/-/versions/-/specs/-")
 	wipeoutArtifacts(ctx, registryClient, taskQueue, project+"/apis/-/versions/-")
 	wipeoutArtifacts(ctx, registryClient, taskQueue, project+"/apis/-/deployments/-")
@@ -111,7 +111,7 @@ func wipeoutProject(ctx context.Context, registryClient connection.Client, taskQ
 	wipeoutApis(ctx, registryClient, taskQueue, project)
 }
 
-func wipeoutArtifacts(ctx context.Context, registryClient connection.Client, taskQueue chan<- core.Task, parent string) {
+func wipeoutArtifacts(ctx context.Context, registryClient connection.RegistryClient, taskQueue chan<- core.Task, parent string) {
 	it := registryClient.ListArtifacts(ctx, &rpc.ListArtifactsRequest{Parent: parent})
 	for artifact, err := it.Next(); err == nil; artifact, err = it.Next() {
 		taskQueue <- &deleteResourceTask{
@@ -122,7 +122,7 @@ func wipeoutArtifacts(ctx context.Context, registryClient connection.Client, tas
 	}
 }
 
-func wipeoutApiDeployments(ctx context.Context, registryClient connection.Client, taskQueue chan<- core.Task, parent string) {
+func wipeoutApiDeployments(ctx context.Context, registryClient connection.RegistryClient, taskQueue chan<- core.Task, parent string) {
 	it := registryClient.ListApiDeployments(ctx, &rpc.ListApiDeploymentsRequest{Parent: parent})
 	for deployment, err := it.Next(); err == nil; deployment, err = it.Next() {
 		taskQueue <- &deleteResourceTask{
@@ -133,7 +133,7 @@ func wipeoutApiDeployments(ctx context.Context, registryClient connection.Client
 	}
 }
 
-func wipeoutApiSpecs(ctx context.Context, registryClient connection.Client, taskQueue chan<- core.Task, parent string) {
+func wipeoutApiSpecs(ctx context.Context, registryClient connection.RegistryClient, taskQueue chan<- core.Task, parent string) {
 	it := registryClient.ListApiSpecs(ctx, &rpc.ListApiSpecsRequest{Parent: parent})
 	for spec, err := it.Next(); err == nil; spec, err = it.Next() {
 		taskQueue <- &deleteResourceTask{
@@ -144,7 +144,7 @@ func wipeoutApiSpecs(ctx context.Context, registryClient connection.Client, task
 	}
 }
 
-func wipeoutApiVersions(ctx context.Context, registryClient connection.Client, taskQueue chan<- core.Task, parent string) {
+func wipeoutApiVersions(ctx context.Context, registryClient connection.RegistryClient, taskQueue chan<- core.Task, parent string) {
 	it := registryClient.ListApiVersions(ctx, &rpc.ListApiVersionsRequest{Parent: parent})
 	for version, err := it.Next(); err == nil; version, err = it.Next() {
 		taskQueue <- &deleteResourceTask{
@@ -155,7 +155,7 @@ func wipeoutApiVersions(ctx context.Context, registryClient connection.Client, t
 	}
 }
 
-func wipeoutApis(ctx context.Context, registryClient connection.Client, taskQueue chan<- core.Task, parent string) {
+func wipeoutApis(ctx context.Context, registryClient connection.RegistryClient, taskQueue chan<- core.Task, parent string) {
 	it := registryClient.ListApis(ctx, &rpc.ListApisRequest{Parent: parent})
 	for api, err := it.Next(); err == nil; api, err = it.Next() {
 		taskQueue <- &deleteResourceTask{

--- a/cmd/registry-graphql/graphql/apis.go
+++ b/cmd/registry-graphql/graphql/apis.go
@@ -17,7 +17,7 @@ package graphql
 import (
 	"errors"
 
-	"github.com/apigee/registry/connection"
+	"github.com/apigee/registry/pkg/connection"
 	"github.com/apigee/registry/rpc"
 	"github.com/graphql-go/graphql"
 )

--- a/cmd/registry-graphql/graphql/artifacts.go
+++ b/cmd/registry-graphql/graphql/artifacts.go
@@ -17,7 +17,7 @@ package graphql
 import (
 	"errors"
 
-	"github.com/apigee/registry/connection"
+	"github.com/apigee/registry/pkg/connection"
 	"github.com/apigee/registry/rpc"
 	"github.com/graphql-go/graphql"
 )

--- a/cmd/registry-graphql/graphql/graphql_test.go
+++ b/cmd/registry-graphql/graphql/graphql_test.go
@@ -21,7 +21,7 @@ import (
 	"log"
 	"testing"
 
-	"github.com/apigee/registry/connection"
+	"github.com/apigee/registry/pkg/connection"
 	"github.com/apigee/registry/rpc"
 	"github.com/graphql-go/graphql"
 	"google.golang.org/grpc/codes"
@@ -149,7 +149,7 @@ type API struct {
 	ID string `json:"id"`
 }
 
-func buildTestProject(ctx context.Context, adminClient connection.AdminClient, registryClient connection.Client, t *testing.T, name string, apiCount int) {
+func buildTestProject(ctx context.Context, adminClient connection.AdminClient, registryClient connection.RegistryClient, t *testing.T, name string, apiCount int) {
 	deleteTestProject(ctx, adminClient, t, name)
 	// Create the test project.
 	req := &rpc.CreateProjectRequest{

--- a/cmd/registry-graphql/graphql/projects.go
+++ b/cmd/registry-graphql/graphql/projects.go
@@ -17,7 +17,7 @@ package graphql
 import (
 	"errors"
 
-	"github.com/apigee/registry/connection"
+	"github.com/apigee/registry/pkg/connection"
 	"github.com/apigee/registry/rpc"
 	"github.com/graphql-go/graphql"
 )

--- a/cmd/registry-graphql/graphql/specs.go
+++ b/cmd/registry-graphql/graphql/specs.go
@@ -17,7 +17,7 @@ package graphql
 import (
 	"errors"
 
-	"github.com/apigee/registry/connection"
+	"github.com/apigee/registry/pkg/connection"
 	"github.com/apigee/registry/rpc"
 	"github.com/graphql-go/graphql"
 )

--- a/cmd/registry-graphql/graphql/versions.go
+++ b/cmd/registry-graphql/graphql/versions.go
@@ -17,7 +17,7 @@ package graphql
 import (
 	"errors"
 
-	"github.com/apigee/registry/connection"
+	"github.com/apigee/registry/pkg/connection"
 	"github.com/apigee/registry/rpc"
 	"github.com/graphql-go/graphql"
 )

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	cloud.google.com/go/cloudtasks v1.0.0
 	cloud.google.com/go/pubsub v1.17.1
 	github.com/GoogleCloudPlatform/cloudsql-proxy v1.26.0
-	github.com/apigee/registry v0.4.2
+	github.com/apigee/registry v0.5.4
 	github.com/blevesearch/bleve v1.0.14
 	github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021
 	github.com/gogo/googleapis v1.4.1

--- a/go.sum
+++ b/go.sum
@@ -86,6 +86,8 @@ github.com/aphistic/golf v0.0.0-20180712155816-02c07f170c5a/go.mod h1:3NqKYiepwy
 github.com/aphistic/sweet v0.2.0/go.mod h1:fWDlIh/isSE9n6EPsRmC0det+whmX6dJid3stzu0Xys=
 github.com/apigee/registry v0.4.2 h1:LpIsf82qqIvd+m/cbXYLVU0hc6apEMjmuJe3N4wpS30=
 github.com/apigee/registry v0.4.2/go.mod h1:rLbgoYe3R0IWiNwfS/Rx8mfmmO3+qoDbPsOdn05T7x4=
+github.com/apigee/registry v0.5.4 h1:lJsw7+ObhhZqSU8TDke5QAEdHoDuJTV/1kGi/+Olx6o=
+github.com/apigee/registry v0.5.4/go.mod h1:Lh1HCHWH+LUd1pKtwTLDKLLrvl0SIp+quZTBJsjdrT8=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
@@ -365,6 +367,7 @@ github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO
 github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0mNTz8vQ=
 github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2pPBoIllUwCN7I=
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
+github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/hudl/fargo v1.3.0/go.mod h1:y3CKSmjA+wD2gak7sUSXTAoopbhU08POFhmITJgmKTg=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=


### PR DESCRIPTION
Updates the apigee/registry dependency to v0.5.4 and fixes problems related to changes.

What changed?
1. The path to the `connection` package is now `pkg/connection`.
2. `connection.Client` is now `connection.RegistryClient`.
3. handlers passed to list operators in `registry/cmd/registry/core` must return `error`.