### PR TITLE
 Finding closest ids complete

### DIFF
--- a/consistency/tool/comparison/comparison.py
+++ b/consistency/tool/comparison/comparison.py
@@ -1,32 +1,63 @@
+from strsimpy.sorensen_dice import SorensenDice
+import sys
+
+
 class Comparison:
-    def __init__(self, stub, spec_vocabs):
+    def __init__(self, stub, new_words):
         self.stub = stub
-        self.spec_vocabs = spec_vocabs
+        self.new_words = new_words
 
-    def get_word_group_ids (self):
-        # TODO: retrieve the WordGroups we have stored from registry. 
-        # return them in an appropriate format for easy comparison 
-        return
-    def find_word_group (self):
-        # TODO: using the list of IDs returned by get_word_group_ids, 
-        # try to find the closest wordgroup for each spec vocab.
-        # if successful, save it in the format vocab:id  else vocab :None
-        # return a list of these
-        return
+    def get_word_group_ids(self):
+        # TODO: retrieve the WordGroups we have stored from registry.
+        # return them in an appropriate format for easy comparison
+        return []
 
-    def find_word_group (self):
+    # format: {word : (cluster_id, distance)}
+    def find_word_groups(self):
+        try:
+            ids = self.get_word_group_ids()
+        except Exception as e:
+            print(e, "Getting word group IDs failed.")
+
+        # the maximum possible score for dice distance is 1, signifying complete dissimilarity.
+        if (
+            ids == None
+            or len(ids) < 1
+            or self.new_words == None
+            or len(self.new_words) < 1
+        ):
+            return None
+
+        def find_closest_id(word):
+            dice = SorensenDice(2)
+            comparsion_info = ["UNIQUE_WORD", 1]
+            for id in ids:
+                distance = dice.distance(word, id)
+
+                # our dice maximal threshold for considering words to be close is ep3 = 0.3
+                if distance < comparsion_info[1] and distance < 0.3:
+                    comparsion_info = [id, distance]
+            return comparsion_info
+
+        closest_word_groups = {}
+        for word in self.new_words:
+            comparison_info = find_closest_id(word)
+            closest_word_groups[word] = comparison_info
+        return closest_word_groups
+
+    def find_word_group(self):
         # TODO: using the map returned by find_word_group,
-        # if the vocab has an associated ID, form a Variation object 
+        # if the vocab has an associated ID, form a Variation object
         # add this object into the current_variations list
-        # if not, check if the vocab is a NOISE_WORD, if not, add it the 
-        # unique_terms list object. If there is a matching word, form a variation object 
-        # from the match -> means creating a wordgroup instance at the dot. 
+        # if not, check if the vocab is a NOISE_WORD, if not, add it the
+        # unique_terms list object. If there is a matching word, form a variation object
+        # from the match -> means creating a wordgroup instance at the dot.
         # return the current variations object
         return
 
-    def find_past_variations (self):
+    def find_past_variations(self):
         # TODO: check the timestamp for the uploaded spec(s) and compare
-        #  against the timestamp of the specs we used in the clustering step. 
-        # if different the variations we last computed are outdated as such are no longer current. 
+        #  against the timestamp of the specs we used in the clustering step.
+        # if different the variations we last computed are outdated as such are no longer current.
         # we recompute the comparison to get current variations
         return

--- a/consistency/tool/comparison/comparison_test.json
+++ b/consistency/tool/comparison/comparison_test.json
@@ -1,0 +1,33 @@
+{
+    "simple":{
+        "ids": [ "google", "apigee", "Gcloud"],
+        "words": [ "Google", "apigees", "gcloud"],
+        "closest_word_groups": {"Google":["google", 0.19999999999999996], 
+                                "apigees":["apigee", 0.09090909090909094],
+                                "gcloud":["Gcloud", 0.19999999999999996]    
+                                }
+    }, 
+    "none-ids":{
+        "ids": null,
+        "words": [ "Google", "apigees", "gcloud"],
+        "closest_word_groups": null
+    }, 
+    "none-words":{
+        "ids": [ "google", "apigee", "Gcloud"],
+        "words": null,
+        "closest_word_groups": null
+    }, 
+    "unique-terms":{
+        "ids": [ "YouTube", "PlayStore", "Stadia"],
+        "words": [ "Google", "apigees", "gcloud"],
+        "closest_word_groups": {"Google":["UNIQUE_WORD", 1], 
+                                "apigees":["UNIQUE_WORD", 1],
+                                "gcloud":["UNIQUE_WORD", 1]    
+                                }
+    }, 
+    "both-null":{
+        "ids": null,
+        "words": null,
+        "closest_word_groups": null
+    }
+}

--- a/consistency/tool/comparison/comparison_test.py
+++ b/consistency/tool/comparison/comparison_test.py
@@ -1,0 +1,36 @@
+import unittest
+import json
+from mock import patch
+from comparison import Comparison
+from parameterized import parameterized
+
+
+class TestComparison(unittest.TestCase):
+    @parameterized.expand(
+        ["simple", "none-ids", "none-words", "unique-terms", "both-null"]
+    )
+    @patch.object(Comparison, "get_word_group_ids")
+    def test_find_word_groups(self, name, mock_get_word_group_ids):
+
+        # PATCH
+        # Construct mock_response
+        with open("comparison_test.json", "r") as myfile:
+            data = myfile.read()
+        obj = json.loads(data)
+        test_suite = obj[name]
+        ids = test_suite["ids"]
+        new_words = test_suite["words"]
+        expected = test_suite["closest_word_groups"]
+
+        mock_get_word_group_ids.return_value = ids
+
+        # CALL
+        cmprsn = Comparison(stub="stub", new_words=new_words)
+        actual = cmprsn.find_word_groups()
+
+        # ASSERT
+        self.assertEqual(actual, expected)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
In this PR, given a list of  ID words for word groups and extracted vocabularies from new specs, we try to find the closest WordGroup for each vocabulary. If there are no close WordGroups, we mark the word as unique to later form the consistency report. The getting IDs part is patched. Unit tested for edge cases and simple words.  