### PR TITLE
Add "artifact-server" to serve artifact contents over HTTP.

### DIFF
--- a/cmd/artifact-server/README.md
+++ b/cmd/artifact-server/README.md
@@ -1,0 +1,40 @@
+# artifact-server
+
+This small HTTP server calls a registry server backend to get the contents of
+artifacts, which it then serves as JSON, YAML, or text (proto) documents
+depending on the Accept type specified in request headers.
+
+`registry get` remains the preferred method for getting artifact contents; this
+adds the ability to get contents from a browser.
+
+artifact-server reads the same configuration as the registry tool.
+```
+$ artifact-server &
+
+$ curl -s http://localhost:8080/projects/sample/locations/global/artifacts/apihub-styleguide -H "Accept: text/json" | head -7
+{
+  "id": "apihub-styleguide",
+  "kind": "StyleGuide",
+  "mimeTypes": [
+    "application/x.protobuf+zip"
+  ],
+  "guidelines": [
+
+$ curl -s http://localhost:8080/projects/sample/locations/global/artifacts/apihub-styleguide -H "Accept: text/yaml" | head -7
+id: apihub-styleguide
+kind: StyleGuide
+mimeTypes:
+    - application/x.protobuf+zip
+guidelines:
+    - id: aip122
+      rules:
+
+$ curl -s http://localhost:8080/projects/sample/locations/global/artifacts/apihub-styleguide -H "Accept: text/plain" | head -7
+id: "apihub-styleguide"
+kind: "StyleGuide"
+mime_types: "application/x.protobuf+zip"
+guidelines: {
+  id: "aip122"
+  rules: {
+    id: "camel-case-uris"
+```

--- a/cmd/artifact-server/main.go
+++ b/cmd/artifact-server/main.go
@@ -95,8 +95,8 @@ func handleRequest(w http.ResponseWriter, req *http.Request) {
 	}
 	accept := req.Header["Accept"]
 	if slices.Contains(accept, "text/json") {
-		fmt.Fprint(w, protojson.Format(message))
-		fmt.Fprint(w, "\n")
+		// The protojson formatting doesn't include a final newline.
+		fmt.Fprintln(w, protojson.Format(message))
 		return
 	}
 	if slices.Contains(accept, "text/yaml") {
@@ -107,9 +107,9 @@ func handleRequest(w http.ResponseWriter, req *http.Request) {
 		fmt.Fprint(w, prototext.Format(message))
 		return
 	}
-	// default return format is JSON
-	fmt.Fprint(w, protojson.Format(message))
-	fmt.Fprint(w, "\n")
+	// Default return format is JSON.
+	// As noted above, the protojson formatting doesn't include a final newline.
+	fmt.Fprintln(w, protojson.Format(message))
 }
 
 func yamlFormat(message proto.Message) string {

--- a/cmd/artifact-server/main.go
+++ b/cmd/artifact-server/main.go
@@ -31,17 +31,17 @@ import (
 	"google.golang.org/protobuf/types/descriptorpb"
 	"gopkg.in/yaml.v3"
 
-	gnostic_metrics_v1 "github.com/google/gnostic/metrics"
-	openapi_v2 "github.com/google/gnostic/openapiv2"
-	openapi_v3 "github.com/google/gnostic/openapiv3"
+	metrics "github.com/google/gnostic/metrics"
+	oas2 "github.com/google/gnostic/openapiv2"
+	oas3 "github.com/google/gnostic/openapiv3"
 )
 
 var messageTypes map[string]proto.Message = map[string]proto.Message{
-	"gnostic.metrics.Complexity":                                   &gnostic_metrics_v1.Complexity{},
-	"gnostic.metrics.VersionHistory":                               &gnostic_metrics_v1.VersionHistory{},
-	"gnostic.metrics.Vocabulary":                                   &gnostic_metrics_v1.Vocabulary{},
-	"gnostic.openapiv2.Document":                                   &openapi_v2.Document{},
-	"gnostic.openapiv3.Document":                                   &openapi_v3.Document{},
+	"gnostic.metrics.Complexity":                                   &metrics.Complexity{},
+	"gnostic.metrics.VersionHistory":                               &metrics.VersionHistory{},
+	"gnostic.metrics.Vocabulary":                                   &metrics.Vocabulary{},
+	"gnostic.openapiv2.Document":                                   &oas2.Document{},
+	"gnostic.openapiv3.Document":                                   &oas3.Document{},
 	"google.cloud.apigeeregistry.applications.v1alpha1.Index":      &rpc.Index{},
 	"google.cloud.apigeeregistry.applications.v1alpha1.Lint":       &rpc.Lint{},
 	"google.cloud.apigeeregistry.applications.v1alpha1.LintStats":  &rpc.LintStats{},

--- a/cmd/artifact-server/main.go
+++ b/cmd/artifact-server/main.go
@@ -1,0 +1,145 @@
+// Copyright 2022 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+
+	"github.com/apigee/registry/cmd/registry/core"
+	"github.com/apigee/registry/pkg/connection"
+	"github.com/apigee/registry/rpc"
+	"golang.org/x/exp/slices"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/encoding/prototext"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/descriptorpb"
+	"gopkg.in/yaml.v3"
+
+	gnostic_metrics_v1 "github.com/google/gnostic/metrics"
+	openapi_v2 "github.com/google/gnostic/openapiv2"
+	openapi_v3 "github.com/google/gnostic/openapiv3"
+)
+
+var messageTypes map[string]proto.Message = map[string]proto.Message{
+	"gnostic.metrics.Complexity":                                   &gnostic_metrics_v1.Complexity{},
+	"gnostic.metrics.VersionHistory":                               &gnostic_metrics_v1.VersionHistory{},
+	"gnostic.metrics.Vocabulary":                                   &gnostic_metrics_v1.Vocabulary{},
+	"gnostic.openapiv2.Document":                                   &openapi_v2.Document{},
+	"gnostic.openapiv3.Document":                                   &openapi_v3.Document{},
+	"google.cloud.apigeeregistry.applications.v1alpha1.Index":      &rpc.Index{},
+	"google.cloud.apigeeregistry.applications.v1alpha1.Lint":       &rpc.Lint{},
+	"google.cloud.apigeeregistry.applications.v1alpha1.LintStats":  &rpc.LintStats{},
+	"google.cloud.apigeeregistry.applications.v1alpha1.References": &rpc.References{},
+	"google.cloud.apigeeregistry.v1.apihub.DisplaySettings":        &rpc.DisplaySettings{},
+	"google.cloud.apigeeregistry.v1.apihub.Lifecycle":              &rpc.Lifecycle{},
+	"google.cloud.apigeeregistry.v1.apihub.ReferenceList":          &rpc.ReferenceList{},
+	"google.cloud.apigeeregistry.v1.apihub.TaxonomyList":           &rpc.TaxonomyList{},
+	"google.cloud.apigeeregistry.v1.controller.Manifest":           &rpc.Manifest{},
+	"google.cloud.apigeeregistry.v1.controller.Receipt":            &rpc.Receipt{},
+	"google.cloud.apigeeregistry.v1.scoring.Score":                 &rpc.Score{},
+	"google.cloud.apigeeregistry.v1.scoring.ScoreCard":             &rpc.ScoreCard{},
+	"google.cloud.apigeeregistry.v1.scoring.ScoreCardDefinition":   &rpc.ScoreCardDefinition{},
+	"google.cloud.apigeeregistry.v1.scoring.ScoreDefinition":       &rpc.ScoreDefinition{},
+	"google.cloud.apigeeregistry.v1.style.ConformanceReport":       &rpc.ConformanceReport{},
+	"google.cloud.apigeeregistry.v1.style.StyleGuide":              &rpc.StyleGuide{},
+	"google.protobuf.FileDescriptorSet":                            &descriptorpb.FileDescriptorSet{},
+}
+
+func handleRequest(w http.ResponseWriter, req *http.Request) {
+	ctx := context.Background()
+	client, err := connection.NewRegistryClient(ctx)
+	if err != nil {
+		writeError(w, err, http.StatusInternalServerError)
+		return
+	}
+	name := strings.TrimPrefix(req.URL.Path, "/")
+	contents, err := client.GetArtifactContents(ctx, &rpc.GetArtifactContentsRequest{Name: name})
+	if err != nil {
+		writeError(w, err, http.StatusNotFound)
+		return
+	}
+	if contents.GetContentType() == "text/plain" {
+		fmt.Fprintf(w, "%s\n", string(contents.GetData()))
+		return
+	}
+	messageType, err := core.MessageTypeForMimeType(contents.GetContentType())
+	if err != nil {
+		writeError(w, err, http.StatusInternalServerError)
+		return
+	}
+	message := messageTypes[messageType]
+	if message == nil {
+		err = fmt.Errorf("unsupported message type: %s", messageType)
+		writeError(w, err, http.StatusInternalServerError)
+		return
+	}
+	if err := proto.Unmarshal(contents.GetData(), message); err != nil {
+		writeError(w, err, http.StatusInternalServerError)
+		return
+	}
+	accept := req.Header["Accept"]
+	if slices.Contains(accept, "text/json") {
+		fmt.Fprint(w, protojson.Format(message))
+		fmt.Fprint(w, "\n")
+		return
+	}
+	if slices.Contains(accept, "text/yaml") {
+		fmt.Fprint(w, yamlFormat(message))
+		return
+	}
+	if slices.Contains(accept, "text/plain") {
+		fmt.Fprint(w, prototext.Format(message))
+		return
+	}
+	// default return format is JSON
+	fmt.Fprint(w, protojson.Format(message))
+	fmt.Fprint(w, "\n")
+}
+
+func yamlFormat(message proto.Message) string {
+	var node yaml.Node
+	err := yaml.Unmarshal([]byte(protojson.Format(message)), &node)
+	if err != nil {
+		return err.Error()
+	}
+	styleForYAML(&node)
+	b, err := yaml.Marshal(node.Content[0])
+	if err != nil {
+		return err.Error()
+	}
+	return string(b)
+}
+
+func styleForYAML(node *yaml.Node) {
+	node.Style = 0
+	for _, n := range node.Content {
+		styleForYAML(n)
+	}
+}
+
+func writeError(w http.ResponseWriter, err error, code int) {
+	http.Error(w, err.Error(), code)
+}
+
+func main() {
+	http.HandleFunc("/", handleRequest)
+	if err := http.ListenAndServe(":8080", nil); err != nil {
+		log.Fatalf("%s", err)
+	}
+}

--- a/cmd/artifact-server/main.go
+++ b/cmd/artifact-server/main.go
@@ -75,7 +75,7 @@ func handleRequest(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 	if contents.GetContentType() == "text/plain" {
-		fmt.Fprintf(w, "%s\n", string(contents.GetData()))
+		fmt.Fprintf(w, "%s\n", contents.GetData())
 		return
 	}
 	messageType, err := core.MessageTypeForMimeType(contents.GetContentType())

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.8.1
+	golang.org/x/exp v0.0.0-20220915210609-840b3808d824
 	golang.org/x/net v0.0.0-20211020060615-d418f374d309
 	golang.org/x/oauth2 v0.0.0-20211005180243-6b3c2da341f1
 	google.golang.org/api v0.58.0
@@ -27,6 +28,7 @@ require (
 	google.golang.org/grpc v1.41.0
 	google.golang.org/protobuf v1.27.1
 	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 	gorm.io/driver/postgres v1.1.0
 	gorm.io/gorm v1.21.14
 )
@@ -53,7 +55,7 @@ require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/snappy v0.0.3 // indirect
 	github.com/google/cel-go v0.8.0 // indirect
-	github.com/google/go-cmp v0.5.6 // indirect
+	github.com/google/go-cmp v0.5.8 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
@@ -90,11 +92,10 @@ require (
 	go.uber.org/zap v1.19.1 // indirect
 	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
-	golang.org/x/sys v0.0.0-20211007075335-d3039528d8ac // indirect
+	golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	gopkg.in/ini.v1 v1.62.0 // indirect
-	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	gorm.io/driver/sqlite v1.1.4 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -284,8 +284,9 @@ github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
+github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
@@ -741,6 +742,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
+golang.org/x/exp v0.0.0-20220915210609-840b3808d824 h1:iRn89vW39OtFmjlBnUXpaiKIPyYGeq2SwquynSjoB/k=
+golang.org/x/exp v0.0.0-20220915210609-840b3808d824/go.mod h1:cyybsKvd6eL0RnXn6p/Grxp8F5bW7iYuBgsNCOHpMYE=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
@@ -911,8 +914,8 @@ golang.org/x/sys v0.0.0-20210831042530-f4d43177bf5e/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210908233432-aa78b53d3365/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210917161153-d61c044b1678/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211004093028-2c5d950f24ef/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20211007075335-d3039528d8ac h1:oN6lz7iLW/YC7un8pq+9bOLyXrprv2+DKfkJY+2LJJw=
-golang.org/x/sys v0.0.0-20211007075335-d3039528d8ac/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f h1:v4INt8xihDGvnrfjMDVXGxw9wrfxYyCjk0KbXjhR55s=
+golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -998,7 +1001,6 @@ golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.3.1/go.mod h1:6wY9I6uQWHQ8EM57III9mq/AjF+i8G65rmVagqKMtkk=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=


### PR DESCRIPTION
This adds a small HTTP server that calls a registry server backend to get the contents of artifacts, which it then serves as JSON, YAML, or [text (proto)](https://developers.google.com/protocol-buffers/docs/text-format-spec) documents depending on the Accept type specified in request headers.

`registry get` remains the preferred method for getting artifact contents; this adds the ability to get contents from a browser.

`artifact-server` reads the same configuration as the `registry` tool.

In the future, we might want to build similar support for Accept headers directly into the [GetArtifactContents](https://github.com/apigee/registry/blob/9ace10b40b183b148223e4d76ba4f15fe4f59590/google/cloud/apigeeregistry/v1/registry_service.proto#L331) method.

```
$ artifact-server &

$ curl -s http://localhost:8080/projects/sample/locations/global/artifacts/apihub-styleguide -H "Accept: text/json" | head -7
{
  "id": "apihub-styleguide",
  "kind": "StyleGuide",
  "mimeTypes": [
    "application/x.protobuf+zip"
  ],
  "guidelines": [

$ curl -s http://localhost:8080/projects/sample/locations/global/artifacts/apihub-styleguide -H "Accept: text/yaml" | head -7
id: apihub-styleguide
kind: StyleGuide
mimeTypes:
    - application/x.protobuf+zip
guidelines:
    - id: aip122
      rules:

$ curl -s http://localhost:8080/projects/sample/locations/global/artifacts/apihub-styleguide -H "Accept: text/plain" | head -7
id: "apihub-styleguide"
kind: "StyleGuide"
mime_types: "application/x.protobuf+zip"
guidelines: {
  id: "aip122"
  rules: {
    id: "camel-case-uris"
```