### PR TITLE
Use the latest version of spectral

### DIFF
--- a/containers/registry-linters/Dockerfile
+++ b/containers/registry-linters/Dockerfile
@@ -41,7 +41,7 @@ ARG REGISTRY_TOOL_IMAGE
 
 # Install spectral linter
 RUN apk add --no-cache nodejs npm
-RUN npm install -g @stoplight/spectral-cli@6.4.1
+RUN npm install -g @stoplight/spectral-cli
 
 # Copy other linter binaries
 COPY --from=builder /go/bin/api-linter /bin/


### PR DESCRIPTION
This commit will update the latest version of spectral in the registry-linters image.

1. Setup the local setup for registry server using docker compose (docker-compose.yaml)
` docker-compose up `

2. Run the following commands to instantiate a linter
`docker run --add-host=host.docker.internal:host-gateway  -it ghcr.io/giteshk-org/registry-linters:main  bash`

3. Create a sample OpenAPI example by running the below command in the linter instance
```
      APG_REGISTRY_ADDRESS=host.docker.internal:8080
      APG_REGISTRY_INSECURE=1
      registry rpc admin create-project --project_id=example --project.name=example --registry.address=${APG_REGISTRY_ADDRESS} --registry.insecure=${APG_REGISTRY_INSECURE}
      registry config configurations create default  --registry.address=$APG_REGISTRY_ADDRESS --registry.insecure=$APG_REGISTRY_INSECURE --registry.project=example --registry.location=global
      wget https://gist.githubusercontent.com/giteshk/b9e1b61e739f6be09ffb40607f84d577/raw/8053315a4542a8821465b0c2c49d5fad394d7b17/petstore-example.yaml
      registry apply -f petstore-example.yaml --parent=projects/example/locations/global

```

4. Apply the style guide
```
      wget https://raw.githubusercontent.com/apigee/registry-experimental/main/samples/apihub-experience/apihub-styleguide.yaml
      registry apply -f apihub-styleguide.yaml --parent="projects/example/locations/global"

```
6.  Compute conformance report

```
      registry compute conformance projects/example/locations/global/apis/petstore-example/versions/v1/specs/petstore.json 

```

7. Verify the artifacts
```
      registry list projects/example/locations/global/apis/petstore-example/versions/v1/specs/petstore.json/artifacts     
      registry get projects/example/locations/global/apis/petstore-example/versions/v1/specs/petstore.json/artifacts/conformance-apihub-styleguide --contents
```