### PR TITLE
Use @google-cloud/apigee-registry library

### DIFF
--- a/containers/registry-mock-server/graphql/README.md
+++ b/containers/registry-mock-server/graphql/README.md
@@ -8,6 +8,9 @@ projects/example/locations/global/apis/api-1/versions/v1/specs/spec-1' The mock
 service will be available at
 http://localhost:3000/projects/example/locations/global/apis/api-1/versions/v1/specs/spec-1
 
+### Running this service on Cloud Run
+[![Run on Google Cloud](https://deploy.cloud.run/button.svg)](https://deploy.cloud.run?dir=containers/registry-mock-server/graphql)
+
 ### To run this service on a GCE instance run the following command:
 
 ```

--- a/containers/registry-mock-server/graphql/src/index.ts
+++ b/containers/registry-mock-server/graphql/src/index.ts
@@ -113,8 +113,7 @@ function processMockRequest(req: Request, res: Response) {
             return _sendError(err, res);
           } else {
             if (response && response.data) {
-              const {data} = response;
-              const specString = <string>data;
+              const specString = response.data.toString();
               fs.mkdirSync(path.dirname(spec_local_path), {recursive: true});
               fs.writeFileSync(spec_local_path, specString);
               executeMockRequest(specString, req, res);
@@ -140,7 +139,6 @@ function executeMockRequest(
   req: express.Request,
   res: express.Response
 ) {
-  console.log(specString);
   const schema = makeExecutableSchema({typeDefs: specString});
 
   const mocks = {
@@ -222,11 +220,10 @@ app.all(
 /**
  * Health check for the service
  */
-app.get('/healthz', (req: Request, res: Response) => {
+app.get('/', (req: Request, res: Response) => {
   res.sendStatus(200);
   res.end();
 });
-
 app.listen(PORT, () =>
   console.log(`Server ready at: http://localhost:${PORT}`)
 );

--- a/containers/registry-mock-server/openapi/README.md
+++ b/containers/registry-mock-server/openapi/README.md
@@ -7,6 +7,9 @@ For a registry spec 'projects/openapi/locations/global/apis/benchtest-1/versions
 The mock service will be available at
 http://localhost:3000/projects/openapi/locations/global/apis/benchtest-1/versions/v1/specs/spec-1
 
+### Running this service on Cloud Run
+[![Run on Google Cloud](https://deploy.cloud.run/button.svg)](https://deploy.cloud.run?dir=containers/registry-mock-server/openapi)
+
 ### To run this service on a GCE instance run the following command:
 ```
 export REGISTRY_PROJECT_IDENTIFIER=$(gcloud config list --format 'value(core.project)')

--- a/containers/registry-spec-renderer/README.md
+++ b/containers/registry-spec-renderer/README.md
@@ -4,6 +4,9 @@ This container allows for rendering of specs from the API Registry.
 Consider running the mock servers for OpenAPI and GraphQL , also setting those 
 endpoints in environment variables (OPENAPI_MOCK_ENDPOINT, GRAPHQL_MOCK_ENDPOINT).
 
+### Running this service on Cloud Run
+[![Run on Google Cloud](https://deploy.cloud.run/button.svg)](https://deploy.cloud.run?dir=containers/registry-spec-renderer)
+
 ### To run this service on a GCE instance run the following command:
 ```
 export REGISTRY_PROJECT_IDENTIFIER=$(gcloud config list --format 'value(core.project)')

--- a/containers/registry-spec-renderer/README.md
+++ b/containers/registry-spec-renderer/README.md
@@ -1,6 +1,9 @@
 # Registry Spec renderer
 This container allows for rendering of specs from the API Registry.
 
+Consider running the mock servers for OpenAPI and GraphQL , also setting those 
+endpoints in environment variables (OPENAPI_MOCK_ENDPOINT, GRAPHQL_MOCK_ENDPOINT).
+
 ### To run this service on a GCE instance run the following command:
 ```
 export REGISTRY_PROJECT_IDENTIFIER=$(gcloud config list --format 'value(core.project)')

--- a/containers/registry-spec-renderer/app.yaml
+++ b/containers/registry-spec-renderer/app.yaml
@@ -1,0 +1,9 @@
+runtime: nodejs16
+env_variables:
+  OPENAPI_MOCK_ENDPOINT : https://prism-mock-server-url
+  GRAPHQL_MOCK_ENDPOINT : https://graphql-mock-server-url
+handlers:
+- url: /.*
+  secure: always
+  redirect_http_response_code: 301
+  script: auto

--- a/containers/registry-spec-renderer/index.js
+++ b/containers/registry-spec-renderer/index.js
@@ -16,11 +16,11 @@
 const express = require('express')
 const fs = require("fs");
 const handlebars = require("handlebars");
-const {RegistryClient} = require("@giteshk-org/apigeeregistry");
+const {RegistryClient} = require("@google-cloud/apigee-registry");
 const {credentials} = require("@grpc/grpc-js");
 const jsYaml = require('js-yaml');
-const { parseURL } = require("whatwg-url");
-var cors = require('cors')
+const {parseURL} = require("whatwg-url");
+const cors = require('cors')
 
 var client_options = {};
 if (process.env.APG_REGISTRY_INSECURE
@@ -28,7 +28,8 @@ if (process.env.APG_REGISTRY_INSECURE
   client_options.sslCreds = credentials.createInsecure();
 }
 
-const MOCK_ENDPOINT = process.env.MOCK_ENDPOINT;
+const OPENAPI_MOCK_ENDPOINT = process.env.OPENAPI_MOCK_ENDPOINT;
+const GRAPHQL_MOCK_ENDPOINT = process.env.GRAPHQL_MOCK_ENDPOINT;
 
 if (process.env.APG_REGISTRY_ADDRESS) {
   items = process.env.APG_REGISTRY_ADDRESS.split(":");
@@ -46,6 +47,7 @@ const async_template = fs.readFileSync("renderers/async-ui.html.template");
 
 const app = express();
 app.use(cors())
+app.use(express.json());
 
 //Serve static assets for openapi renderer
 app.use('/renderer/openapi',
@@ -66,27 +68,35 @@ app.use('/renderer/graphql', express.static('node_modules/graphiql'))
 
 function renderTemplate(res, apiFormat, spec_name) {
   var renderer_template = "";
+  var api_endpoint = res.locals.endpoint_uri ? res.locals.endpoint_uri : "";
   switch (apiFormat) {
     case "openapi":
       renderer_template = swagger_ui_template.toString();
+      if (!api_endpoint && OPENAPI_MOCK_ENDPOINT) {
+        api_endpoint = OPENAPI_MOCK_ENDPOINT + "/" + spec_name;
+      }
       break;
     case "asyncapi":
       renderer_template = async_template.toString();
       break;
     case "graphql":
       renderer_template = graphiql_template.toString();
+      if (!api_endpoint && GRAPHQL_MOCK_ENDPOINT) {
+        api_endpoint = GRAPHQL_MOCK_ENDPOINT + "/" + spec_name
+      }
       break;
     default:
       renderer_template = "spec_file"
       break;
   }
-  specUrl = "/spec/" + apiFormat + "/" + spec_name;
+  spec_url = "/spec/" + apiFormat + "/" + spec_name + (api_endpoint
+      ? "?endpoint_uri=" + encodeURI(api_endpoint) : "");
   if (renderer_template != "spec_file") {
     res.setHeader("content-type", "text/html; charset=UTF-8");
     hbstemplate = handlebars.compile(renderer_template);
-    res.send(hbstemplate({specUrl: specUrl}));
+    res.send(hbstemplate({specUrl: spec_url, apiEndpoint: api_endpoint}));
   } else {
-    res.redirect(specUrl);
+    res.redirect(spec_url);
   }
   res.end();
 }
@@ -129,7 +139,13 @@ app.get(
           res.sendStatus(500);
           res.end();
         } else {
-          res.redirect(302, "/render/" + deployment.apiSpecRevision);
+          let queryString = "";
+          if (deployment.endpointUri) {
+            queryString += "endpoint_uri=" + encodeURI(deployment.endpointUri);
+          }
+          res.redirect(302,
+              "/render/" + deployment.apiSpecRevision + (queryString ? "?"
+                  + queryString : ""));
         }
       })
     });
@@ -145,7 +161,9 @@ app.get(
           + req.params.locationId + "/apis/" + req.params.apiId;
       spec_name = api_name + "/versions/"
           + req.params.versionId + "/specs/" + req.params.specId;
-
+      if (req.query.endpoint_uri) {
+        res.locals.endpoint_uri = decodeURI(req.query.endpoint_uri);
+      }
       client.getApiSpec({
         name: spec_name
       }, (err, response) => {
@@ -154,8 +172,10 @@ app.get(
           res.sendStatus(500);
           res.end();
         } else {
+
           apiFormat = getAPIFormat(response.mimeType);
-          if (apiFormat == '') {
+
+          if (!apiFormat) {
             client.getApi({
               name: api_name
             }, (err, response2) => {
@@ -164,6 +184,7 @@ app.get(
                 res.sendStatus(500);
                 res.end();
               } else {
+
                 apiFormat = '';
                 if (response2.labels['apihub-style']) {
                   apiFormat = getAPIFormat(
@@ -190,16 +211,19 @@ app.all(
         res.end();
         return;
       }
-
+      if (req.query.endpoint_uri) {
+        res.locals.endpoint_uri = decodeURI(req.query.endpoint_uri);
+      }
       let spec_url = "projects/" + req.params.projectId + "/locations/"
           + req.params.locationId + "/apis/" + req.params.apiId + "/versions/"
           + req.params.versionId + "/specs/" + req.params.specId;
       let api_url = "projects/" + req.params.projectId + "/locations/"
           + req.params.locationId + "/apis/" + req.params.apiId;
+
       client.getApiSpecContents(
           {
             name: spec_url
-          }, (err, response) => {
+          }, async (err, response) => {
             if (err) {
               console.error(err);
               res.sendStatus(500);
@@ -222,6 +246,7 @@ app.all(
             }
           })
     });
+
 /**
  * Filter the list of deployments with the matching spec revision.
  *
@@ -246,28 +271,38 @@ function addMockAddressForOpenAPI(openAPISpecObj, spec_url, api_url, res) {
       console.error(err);
     }
 
-    if(!deployments) {
+    if (!deployments) {
       deployments = [];
     }
 
-    if (MOCK_ENDPOINT) {
+    if (OPENAPI_MOCK_ENDPOINT) {
       deployments.push({
-        endpointUri: MOCK_ENDPOINT + "/" + spec_url,
+        endpointUri: OPENAPI_MOCK_ENDPOINT + "/" + spec_url,
         displayName: "Mock Service"
       });
     }
 
+    /**
+     * Handle OpenAPI 2.0 specs
+     */
+    if (openAPISpecObj.swagger && openAPISpecObj.swagger.startsWith("2")) {
+      let endpoint = deployments.length > 0 ? deployments[0].endpointUri : "";
+      if (res.locals.endpoint_uri) {
+        endpoint = res.locals.endpoint_uri;
+      }
+      if (endpoint) {
+        let parsedUrl = parseURL(endpoint);
+        openAPISpecObj.host = parsedUrl.host + (parsedUrl.port ? ":"
+            + parsedUrl.port : "");
+        openAPISpecObj.basePath = "/" + parsedUrl.path.join("/");
+        openAPISpecObj.schemes = [parsedUrl.scheme];
+      }
+    }
     deployments.forEach(deployment => {
       if (!deployment.endpointUri) {
         return;
       }
-      if (openAPISpecObj.swagger && openAPISpecObj.swagger.startsWith("2")
-          && !openAPISpecObj.host) {
-        let parsedUrl = parseURL(deployment.endpointUri);
-        openAPISpecObj.host = parsedUrl.host;
-        openAPISpecObj.basePath = "/" + parsedUrl.path.join("/");
-        openAPISpecObj.schemes = [parsedUrl.scheme];
-      } else if (openAPISpecObj.openapi &&
+      if (openAPISpecObj.openapi &&
           openAPISpecObj.openapi.startsWith("3")) {
         openAPISpecObj = openAPISpecObj || {
           servers: []
@@ -279,7 +314,6 @@ function addMockAddressForOpenAPI(openAPISpecObj, spec_url, api_url, res) {
             });
       }
     })
-
 
     res.json(openAPISpecObj);
     res.end();

--- a/containers/registry-spec-renderer/index.js
+++ b/containers/registry-spec-renderer/index.js
@@ -46,25 +46,26 @@ const graphiql_template = fs.readFileSync("renderers/graphiql.html.template");
 const async_template = fs.readFileSync("renderers/async-ui.html.template");
 
 const app = express();
+app.set('trust proxy', true);
 app.use(cors())
 app.use(express.json());
 
 //Serve static assets for openapi renderer
-app.use('/renderer/openapi',
+app.use('/swagger-ui',
     express.static(require('swagger-ui-dist').absolutePath()))
 
 //Serve static assets for asyncapi renderer
-app.use('/renderer/async',
+app.use('/asyncapi/webcomponents/webcomponentsjs',
     express.static('node_modules/@webcomponents/webcomponentsjs'))
-app.use('/renderer/async',
+app.use('/asyncapi/web-component',
     express.static('node_modules/@asyncapi/web-component'))
-app.use('/renderer/async',
+app.use('/asyncapi/react-component',
     express.static('node_modules/@asyncapi/react-component'))
 
 //Serve static assets for graphql renderer
-app.use('/renderer/graphql', express.static('node_modules/react'))
-app.use('/renderer/graphql', express.static('node_modules/react-dom'))
-app.use('/renderer/graphql', express.static('node_modules/graphiql'))
+app.use('/graphql/react', express.static('node_modules/react'))
+app.use('/graphql/react-dom', express.static('node_modules/react-dom'))
+app.use('/graphql/graphiql', express.static('node_modules/graphiql'))
 
 function renderTemplate(res, apiFormat, spec_name) {
   var renderer_template = "";
@@ -320,7 +321,7 @@ function addMockAddressForOpenAPI(openAPISpecObj, spec_url, api_url, res) {
   });
 }
 
-app.get('/healthz', (req, res) => {
+app.get('/', (req, res) => {
   res.sendStatus(200);
   res.end();
 });

--- a/containers/registry-spec-renderer/package.json
+++ b/containers/registry-spec-renderer/package.json
@@ -9,17 +9,20 @@
   "author": "Gitesh Koli",
   "license": "Apache-2.0",
   "dependencies": {
-    "@asyncapi/react-component": "^0.24.19",
-    "@asyncapi/web-component": "^0.24.19",
-    "@giteshk-org/apigeeregistry": "^0.0.1",
+    "@asyncapi/react-component": "^0.24.23",
+    "@asyncapi/web-component": "^0.24.23",
+    "@google-cloud/apigee-registry": "^0.2.1",
+    "@graphql-tools/load": "^7.7.7",
+    "@graphql-tools/mock": "^8.7.6",
     "@webcomponents/webcomponentsjs": "^2.6.0",
     "cors": "^2.8.5",
-    "express": "^4.17.2",
-    "graphiql": "^1.5.16",
+    "express": "^4.18.1",
+    "graphiql": "^1.11.5",
+    "graphql": "^16.6.0",
     "handlebars": "^4.7.7",
     "js-yaml": "^4.1.0",
     "react-dom": "^17.0.2",
-    "swagger-ui-dist": "^4.1.3",
+    "swagger-ui-dist": "^4.14.2",
     "whatwg-url": "^11.0.0"
   }
 }

--- a/containers/registry-spec-renderer/renderers/async-ui.html.template
+++ b/containers/registry-spec-renderer/renderers/async-ui.html.template
@@ -1,16 +1,15 @@
 <html>
   <head>
-    <title>Async API Sample</title>
+    <title>Async API</title>
   </head>
-  <body style="margin: 0;">
-
-<script src="/renderer/async/webcomponents-bundle.js"></script>
-<script src="/renderer/async/lib/asyncapi-web-component.js" defer></script>
+  <body style="margin: 20px">
+<script src="/asyncapi/webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
+<script src="/asyncapi/web-component/lib/asyncapi-web-component.js" defer></script>
 
 <asyncapi-component
   schemaUrl="{{{specUrl}}}"
   schemaFetchOptions='{"method":"GET","mode":"cors"}'
-  cssImportPath="/renderer/async/lib/styles/fiori.css">
+  cssImportPath="/asyncapi/react-component/lib/styles/fiori.css">
 </asyncapi-component>
 
   </body>

--- a/containers/registry-spec-renderer/renderers/graphiql.html.template
+++ b/containers/registry-spec-renderer/renderers/graphiql.html.template
@@ -20,7 +20,7 @@
     ></script>
 
     <script>
-      const fetcher = GraphiQL.createFetcher({ url: '{{{specUrl}}}' });
+      const fetcher = GraphiQL.createFetcher({ url: '{{{apiEndpoint}}}' });
 
       ReactDOM.render(
         React.createElement(GraphiQL, { fetcher: fetcher }),

--- a/containers/registry-spec-renderer/renderers/graphiql.html.template
+++ b/containers/registry-spec-renderer/renderers/graphiql.html.template
@@ -1,27 +1,15 @@
 <html>
   <head>
-    <title>Simple GraphiQL Example</title>
-    <link href="/renderer/graphql/graphiql.min.css" rel="stylesheet" />
+    <title>GraphiQL</title>
+    <link href="/graphql/graphiql/graphiql.min.css" rel="stylesheet" />
   </head>
   <body style="margin: 0;">
     <div id="graphiql" style="height: 100vh;"></div>
-
-    <script
-      crossorigin
-      src="/renderer/graphql/umd/react.production.min.js"
-    ></script>
-    <script
-      crossorigin
-      src="/renderer/graphql/umd/react-dom.production.min.js"
-    ></script>
-    <script
-      crossorigin
-      src="/renderer/graphql/graphiql.min.js"
-    ></script>
-
+    <script  crossorigin   src="/graphql/react/umd/react.production.min.js"></script>
+    <script  crossorigin   src="/graphql/react-dom/umd/react-dom.production.min.js"></script>
+    <script  crossorigin   src="/graphql/graphiql/graphiql.min.js"></script>
     <script>
       const fetcher = GraphiQL.createFetcher({ url: '{{{apiEndpoint}}}' });
-
       ReactDOM.render(
         React.createElement(GraphiQL, { fetcher: fetcher }),
         document.getElementById('graphiql'),

--- a/containers/registry-spec-renderer/renderers/swagger-ui.html.template
+++ b/containers/registry-spec-renderer/renderers/swagger-ui.html.template
@@ -4,12 +4,9 @@
   <head>
     <meta charset="UTF-8">
     <title>Swagger UI</title>
-    <link rel="stylesheet" type="text/css" href="/renderer/openapi/swagger-ui.css" />
-    <link rel="icon" type="image/png" href="/renderer/openapi/favicon-32x32.png" sizes="32x32" />
-    <link rel="icon" type="image/png" href="/renderer/openapi/favicon-16x16.png" sizes="16x16" />
-    <script src="https://apis.google.com/js/platform.js" async defer></script>
-    <meta name="google-signin-client_id" content="YOUR_CLIENT_ID.apps.googleusercontent.com">
-
+    <link rel="stylesheet" type="text/css" href="/swagger-ui/swagger-ui.css" />
+    <link rel="icon" type="image/png" href="/swagger-ui/favicon-32x32.png" sizes="32x32" />
+    <link rel="icon" type="image/png" href="/swagger-ui/favicon-16x16.png" sizes="16x16" />
     <style>
       html
       {
@@ -36,8 +33,8 @@
   <body>
     <div id="swagger-ui"></div>
 
-    <script src="/renderer/openapi/swagger-ui-bundle.js" charset="UTF-8"> </script>
-    <script src="/renderer/openapi/swagger-ui-standalone-preset.js" charset="UTF-8"> </script>
+    <script src="/swagger-ui/swagger-ui-bundle.js" charset="UTF-8"> </script>
+    <script src="/swagger-ui/swagger-ui-standalone-preset.js" charset="UTF-8"> </script>
     <script>
     window.onload = function() {
       // Begin Swagger UI call region


### PR DESCRIPTION
1. Fixed GraphiQL renderer (This depends on Graphql Mock server being setup)

2. Added ability to provide mock endpoints