### PR TITLE
GRPC documentation generation POC

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -56,6 +56,9 @@ jobs:
         -   image: ${{github.repository_owner}}/registry-linters
             context: "."
             dockerfile: "containers/registry-linters/Dockerfile"
+        -   image: ${{github.repository_owner}}/registry-protoc-gen-doc
+            context: "containers/registry-protoc-gen-doc"
+            dockerfile: "containers/registry-protoc-gen-doc/Dockerfile"
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2

--- a/containers/registry-protoc-gen-doc/Dockerfile
+++ b/containers/registry-protoc-gen-doc/Dockerfile
@@ -1,0 +1,31 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM pseudomuto/protoc-gen-doc:1.5 as protoc-gen-doc
+
+FROM ghcr.io/apigee/registry-tools:latest
+
+RUN apk update && apk add --no-cache protobuf \
+    && mkdir -p /protoc/include/
+
+COPY --from=protoc-gen-doc /usr/bin/protoc-gen-doc /bin/
+COPY --from=protoc-gen-doc /usr/include/google /protoc/include/google/
+
+RUN find /protoc/include/ -type f ! -iname "*.proto" -delete
+
+COPY ./doc-gen.sh /
+
+RUN chmod +x /doc-gen.sh
+
+RUN git clone https://github.com/googleapis/api-common-protos /googleapis-common-protos

--- a/containers/registry-protoc-gen-doc/README.md
+++ b/containers/registry-protoc-gen-doc/README.md
@@ -5,7 +5,38 @@ We will be running the registry controller with a custom manifest which can :
 - store the generated markup to Google Storage bucket
 - store the reference to the GCS object, as an artifact `grpc-documentation`, on the spec object.
 
-## Steps to set up this solution
+## Run this solution on location machine
+1. Create a Google storage bucket to use for this setup.
+2. Install [protoc](https://grpc.io/docs/protoc-installation/)
+3. Install [protoc-gen-doc](https://github.com/pseudomuto/protoc-gen-doc)
+4. Download Google APIs common protos using 
+   ```
+     git clone https://github.com/googleapis/api-common-protos
+   ```
+5. Updates the action field in the manifest file `registry-protoc-gen-doc-controller.yaml`
+   ```
+   /tmp/doc-gen.sh $resource.spec grpc-docs  /path/to/api-common-protos
+   ```
+   1. First parameter is the absolute path to doc-gen.sh file 
+   2. Second parameter to the doc-gen.sh file is the name of the GCS bucket
+   3. Third parameter is the spec reference 
+   4. Fourth parameter is the path to the protos from https://github.com/googleapis/api-common-protos
+      1. This could be referenced by any other common protos from your project
+6. Upload the manifest for this controller to the Registry project
+   ```shell
+   export TOKEN=$(gcloud auth print-access-token)
+   registry upload manifest ./registry-protoc-gen-doc-manifest.yaml
+   ```
+7. To generate the HTML markup and the artifacts on the spec run the following
+    ```shell
+    registry resolve artifacts/registry-protoc-gen-doc
+    ```
+8. List the artifacts using the below command
+    ```shell
+   registry list apis/-/versions/-/specs/-/artifacts/grpc-doc-url
+    ```
+
+## Run this solution on GKE
 1. Create a Google storage bucket to use for this setup.
 2. Update the manifest file `registry-protoc-gen-doc-controller.yaml` with the
    name of the bucket (replace grpc-docs).

--- a/containers/registry-protoc-gen-doc/README.md
+++ b/containers/registry-protoc-gen-doc/README.md
@@ -1,9 +1,11 @@
 # Generating Documentation from protos
 
-We will be creating a custom controller which can generate html documentation
-using [protoc-gen-doc](https://github.com/pseudomuto/protoc-gen-doc) and store
-the generated markup to an artifact `grpc-documentation` on the spec object.
+We will be running the registry controller with a custom manifest which can :
+- generate html documentation using [protoc-gen-doc](https://github.com/pseudomuto/protoc-gen-doc)
+- store the generated markup to Google Storage bucket
+- store the reference to the GCS object, as an artifact `grpc-documentation`, on the spec object.
 
+## Steps to set up this solution
 1. Create a Google storage bucket to use for this setup.
 2. Update the manifest file `registry-protoc-gen-doc-controller.yaml` with the
    name of the bucket (replace grpc-docs).
@@ -12,7 +14,7 @@ the generated markup to an artifact `grpc-documentation` on the spec object.
    PROJECT_ID=<GCP_PROJECT_NAME>
    registry upload manifest ./registry-protoc-gen-doc-manifest.yaml --project-id=${PROJECT_ID}
    ```
-4. Deploy to controller to GKE
+4. Deploy the controller to GKE
     1. Create a GKE cluster
        with [WorkLoad Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity)
        enabled.

--- a/containers/registry-protoc-gen-doc/README.md
+++ b/containers/registry-protoc-gen-doc/README.md
@@ -25,15 +25,17 @@ We will be running the registry controller with a custom manifest which can :
 6. Upload the manifest for this controller to the Registry project
    ```shell
    export TOKEN=$(gcloud auth print-access-token)
-   registry upload manifest ./registry-protoc-gen-doc-manifest.yaml
+   export REGISTRY_ADDRESS="apigeeregistry.googleapis.com:443"
+   export PROJECT_ID=<project_name>
+   registry upload manifest ./registry-protoc-gen-doc-manifest.yaml --project-id=$PROJECT_ID --registry.token=$TOKEN --registry.address=$REGISTRY_ADDRESS
    ```
 7. To generate the HTML markup and the artifacts on the spec run the following
     ```shell
-    registry resolve artifacts/registry-protoc-gen-doc
+    registry resolve projects/$PROJECT_ID/locations/global/artifacts/registry-protoc-gen-doc
     ```
 8. List the artifacts using the below command
     ```shell
-   registry list apis/-/versions/-/specs/-/artifacts/grpc-doc-url
+   registry list projects/$PROJECT_ID/locations/global/apis/-/versions/-/specs/-/artifacts/grpc-doc-url
     ```
 
 ## Run this solution on GKE
@@ -85,7 +87,7 @@ We will be running the registry controller with a custom manifest which can :
 
 ```shell
   #Delete grpc-doc-url artifact for all specs in registry 
-  registry delete apis/-/versions/-/specs/-/artifacts/grpc-doc-url
   #Delete the files from the GCS bucket
+  registry delete apis/-/versions/-/specs/-/artifacts/grpc-doc-url
   gsutil rm -rf gs://grpc-docs/*
 ```

--- a/containers/registry-protoc-gen-doc/README.md
+++ b/containers/registry-protoc-gen-doc/README.md
@@ -1,50 +1,55 @@
-#Generating Documentation from protos
+# Generating Documentation from protos
 
 We will be creating a custom controller which can generate html documentation
 using [protoc-gen-doc](https://github.com/pseudomuto/protoc-gen-doc) and store
 the generated markup to an artifact `grpc-documentation` on the spec object.
 
 1. Create a Google storage bucket to use for this setup.
-2. Update the manifest file `registry-protoc-gen-doc-controller.yaml` with the name of the bucket (replace grpc-docs).
+2. Update the manifest file `registry-protoc-gen-doc-controller.yaml` with the
+   name of the bucket (replace grpc-docs).
 3. Upload the manifest for this controller to the Registry project
    ```
    PROJECT_ID=<GCP_PROJECT_NAME>
    registry upload manifest ./registry-protoc-gen-doc-manifest.yaml --project-id=${PROJECT_ID}
    ```
-4. Deploy to controller to GKE 
-   1. Create a GKE cluster with [WorkLoad Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) enabled.
-   2. Create a IAM Service account
-      ```shell
-    
-      gcloud iam service-accounts create registry-admin-gsa --project=${PROJECT_ID}
-      
-      gcloud projects add-iam-policy-binding $PROJECT_ID \
-      --member "serviceAccount:registry-admin-gsa@${PROJECT_ID}.iam.gserviceaccount.com" \
-      --role "roles/apigeeregistry.admin"
-      
-      gcloud projects add-iam-policy-binding $PROJECT_ID \
-      --member "serviceAccount:registry-admin-gsa@${PROJECT_ID}.iam.gserviceaccount.com" \
-      --role "roles/storage.objectAdmin"
-      ```
-   3. Configure workload identity for the service account
-         ```
-         gcloud iam service-accounts add-iam-policy-binding registry-admin-gsa@${PROJECT_ID}.iam.gserviceaccount.com \
-         --role roles/iam.workloadIdentityUser \
-         --member "serviceAccount:${PROJECT_ID}.svc.id.goog[registry-custom/registry-admin-ksa]"
-      
-         ``` 
-   4. Apply the kubernetes configuration to the cluster
-      ```
-        kubectl apply -f registry-protoc-gen-doc-controller.yaml
-      ```
-   5. Annotate the Kubernetes service account with the email address of the IAM service account.
-      ```
-        kubectl annotate serviceaccount registry-admin-ksa \
-          --namespace registry-custom \
-         iam.gke.io/gcp-service-account=registry-admin-gsa@${PROJECT_ID}.iam.gserviceaccount.com
-      ```
+4. Deploy to controller to GKE
+    1. Create a GKE cluster
+       with [WorkLoad Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity)
+       enabled.
+    2. Create a IAM Service account
+       ```shell
+     
+       gcloud iam service-accounts create registry-admin-gsa --project=${PROJECT_ID}
+       
+       gcloud projects add-iam-policy-binding $PROJECT_ID \
+       --member "serviceAccount:registry-admin-gsa@${PROJECT_ID}.iam.gserviceaccount.com" \
+       --role "roles/apigeeregistry.admin"
+       
+       gcloud projects add-iam-policy-binding $PROJECT_ID \
+       --member "serviceAccount:registry-admin-gsa@${PROJECT_ID}.iam.gserviceaccount.com" \
+       --role "roles/storage.objectAdmin"
+       ```
+    3. Configure workload identity for the service account
+          ```
+          gcloud iam service-accounts add-iam-policy-binding registry-admin-gsa@${PROJECT_ID}.iam.gserviceaccount.com \
+          --role roles/iam.workloadIdentityUser \
+          --member "serviceAccount:${PROJECT_ID}.svc.id.goog[registry-custom/registry-admin-ksa]"
+       
+          ``` 
+    4. Apply the kubernetes configuration to the cluster
+       ```
+         kubectl apply -f registry-protoc-gen-doc-controller.yaml
+       ```
+    5. Annotate the Kubernetes service account with the email address of the IAM
+       service account.
+       ```
+         kubectl annotate serviceaccount registry-admin-ksa \
+           --namespace registry-custom \
+          iam.gke.io/gcp-service-account=registry-admin-gsa@${PROJECT_ID}.iam.gserviceaccount.com
+       ```
 
 ## Delete all the GRPC documentation artifacts
+
 ```shell
   #Delete grpc-doc-url artifact for all specs in registry 
   registry delete apis/-/versions/-/specs/-/artifacts/grpc-doc-url

--- a/containers/registry-protoc-gen-doc/README.md
+++ b/containers/registry-protoc-gen-doc/README.md
@@ -1,0 +1,53 @@
+#Generating Documentation from protos
+
+We will be creating a custom controller which can generate html documentation
+using [protoc-gen-doc](https://github.com/pseudomuto/protoc-gen-doc) and store
+the generated markup to an artifact `grpc-documentation` on the spec object.
+
+1. Create a Google storage bucket to use for this setup.
+2. Update the manifest file `registry-protoc-gen-doc-controller.yaml` with the name of the bucket (replace grpc-docs).
+3. Upload the manifest for this controller to the Registry project
+   ```
+   PROJECT_ID=<GCP_PROJECT_NAME>
+   registry upload manifest ./registry-protoc-gen-doc-manifest.yaml --project-id=${PROJECT_ID}
+   ```
+4. Deploy to controller to GKE 
+   1. Create a GKE cluster with [WorkLoad Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) enabled.
+   2. Create a IAM Service account
+      ```shell
+    
+      gcloud iam service-accounts create registry-admin-gsa --project=${PROJECT_ID}
+      
+      gcloud projects add-iam-policy-binding $PROJECT_ID \
+      --member "serviceAccount:registry-admin-gsa@${PROJECT_ID}.iam.gserviceaccount.com" \
+      --role "roles/apigeeregistry.admin"
+      
+      gcloud projects add-iam-policy-binding $PROJECT_ID \
+      --member "serviceAccount:registry-admin-gsa@${PROJECT_ID}.iam.gserviceaccount.com" \
+      --role "roles/storage.objectCreator"
+      ```
+   3. Configure workload identity for the service account
+         ```
+         gcloud iam service-accounts add-iam-policy-binding registry-admin-gsa@${PROJECT_ID}.iam.gserviceaccount.com \
+         --role roles/iam.workloadIdentityUser \
+         --member "serviceAccount:${PROJECT_ID}.svc.id.goog[registry-custom/registry-admin-ksa]"
+      
+         ``` 
+   4. Apply the kubernetes configuration to the cluster
+      ```
+        kubectl apply -f registry-protoc-gen-doc-controller.yaml
+      ```
+   5. Annotate the Kubernetes service account with the email address of the IAM service account.
+      ```
+        kubectl annotate serviceaccount registry-admin-ksa \
+          --namespace registry-custom \
+         iam.gke.io/gcp-service-account=registry-admin-gsa@${PROJECT_ID}.iam.gserviceaccount.com
+      ```
+
+## Delete all the GRPC documentation artifacts
+```shell
+  #Delete grpc-doc-url artifact for all specs in registry 
+  registry delete apis/-/versions/-/specs/-/artifacts/grpc-doc-url
+  #Delete the files from the GCS bucket
+  gsutil rm -rf gs://grpc-docs/*
+```

--- a/containers/registry-protoc-gen-doc/README.md
+++ b/containers/registry-protoc-gen-doc/README.md
@@ -24,7 +24,7 @@ the generated markup to an artifact `grpc-documentation` on the spec object.
       
       gcloud projects add-iam-policy-binding $PROJECT_ID \
       --member "serviceAccount:registry-admin-gsa@${PROJECT_ID}.iam.gserviceaccount.com" \
-      --role "roles/storage.objectCreator"
+      --role "roles/storage.objectAdmin"
       ```
    3. Configure workload identity for the service account
          ```

--- a/containers/registry-protoc-gen-doc/doc-gen.sh
+++ b/containers/registry-protoc-gen-doc/doc-gen.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+set -euo pipefail
+
+# command expect name of the spec and the name of the bucket where html docs will be generated
+args=("$@")
+SPEC=${args[0]}
+BUCKET_NAME=${args[1]}
+GRPC_GEN_DOC_FILE="index.html"
+
+echo "Started processing $SPEC"
+
+TOKEN=$(curl -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token | jq .access_token -r)
+SPEC_PATH="/tmp/workspace/$SPEC"
+
+rm -rf "$SPEC_PATH"
+
+mkdir -p "$SPEC_PATH"
+
+SPEC_DETAILS=$(registry get  $SPEC --registry.token=$TOKEN --registry.address=${REGISTRY_ADDRESS})
+MIMETYPE=$( echo $SPEC_DETAILS | jq -r .mimeType)
+FILENAME=$( echo $SPEC_DETAILS | jq -r .filename)
+
+registry get $SPEC  --contents --registry.token=$TOKEN --registry.address=${REGISTRY_ADDRESS} > "$SPEC_PATH/$FILENAME"
+
+if [ $MIMETYPE == "application/x.protobuf+gzip" ]; then
+  tar -xf "$SPEC_PATH/$FILENAME" -C "$SPEC_PATH"
+  # Mac OS gziped files may contain archive files
+  # https://en.wikipedia.org/wiki/AppleSingle_and_AppleDouble_formats
+  rm -rf "$SPEC_PATH/.*"
+fi
+
+find "$SPEC_PATH" -type f -name "*.proto"  > "$SPEC_PATH/proto-files.txt"
+
+echo "About to generate documentation for $SPEC"
+
+protoc @"$SPEC_PATH/proto-files.txt" \
+  --proto_path="$SPEC_PATH" \
+  --proto_path="/protoc/include" \
+  --proto_path="/googleapis-common-protos" \
+  --doc_out="$SPEC_PATH" --doc_opt=html,$GRPC_GEN_DOC_FILE
+
+GCS_FILE_URL="https://storage.googleapis.com/$BUCKET_NAME/$SPEC/$GRPC_GEN_DOC_FILE"
+
+echo "About to upload generated documentation for $SPEC to gs://$BUCKET_NAME"
+
+curl --upload-file "$SPEC_PATH/$GRPC_GEN_DOC_FILE" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: text/html" \
+  "$GCS_FILE_URL"
+
+ARTIFACT_CONTENT=$(echo "$GCS_FILE_URL" | xxd -p | tr -d '\n')
+
+echo "About to create grpc-doc-url artifact for $SPEC"
+
+registry rpc create-artifact \
+  --parent="$SPEC" \
+  --artifact_id="grpc-doc-url" \
+  --artifact.mime_type="text/plain" \
+  --artifact.contents="$ARTIFACT_CONTENT" \
+  --registry.address="${REGISTRY_ADDRESS}" \
+  --registry.token="$TOKEN"
+
+echo "Finished processing $SPEC"

--- a/containers/registry-protoc-gen-doc/registry-protoc-gen-doc-controller.yaml
+++ b/containers/registry-protoc-gen-doc/registry-protoc-gen-doc-controller.yaml
@@ -1,3 +1,17 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/containers/registry-protoc-gen-doc/registry-protoc-gen-doc-controller.yaml
+++ b/containers/registry-protoc-gen-doc/registry-protoc-gen-doc-controller.yaml
@@ -1,0 +1,57 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: registry-custom
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: registry-admin-ksa
+  namespace: registry-custom
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: registry-protoc-gen-doc-controller
+  namespace: registry-custom
+spec:
+  schedule: "*/30 * * * *"
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 100
+  suspend: false
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    metadata:
+      labels:
+        app: registry-protoc-gen-doc-controller
+    spec:
+      template:
+        metadata:
+          labels:
+            app: registry-protoc-gen-doc-controller
+        spec:
+          serviceAccountName: registry-admin-ksa
+          nodeSelector:
+            iam.gke.io/gke-metadata-server-enabled: "true"
+          containers:
+          - name: registry-protoc-gen-doc
+            image: ghcr.io/apigee/registry-protoc-gen-doc:main
+            env:
+            - name: REGISTRY_ADDRESS
+              value: "apigeeregistry.googleapis.com:443"
+            args:
+            - bin/sh
+            - -c
+            - |
+              REGISTRY_PROJECT_NAME=$(curl -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/project/project-id)
+              
+              TOKEN=$(curl -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token | jq .access_token -r)
+
+              registry resolve projects/${REGISTRY_PROJECT_NAME}/locations/global/artifacts/registry-protoc-gen-doc \
+                --registry.token=$TOKEN --registry.address=${REGISTRY_ADDRESS}
+
+              rc=$(echo $?)
+              exit $rc
+          restartPolicy: Never
+      backoffLimit: 3

--- a/containers/registry-protoc-gen-doc/registry-protoc-gen-doc-controller.yaml
+++ b/containers/registry-protoc-gen-doc/registry-protoc-gen-doc-controller.yaml
@@ -58,12 +58,16 @@ spec:
             - bin/sh
             - -c
             - |
-              REGISTRY_PROJECT_NAME=$(curl -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/project/project-id)
-              
-              TOKEN=$(curl -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token | jq .access_token -r)
+              export REGISTRY_PROJECT_NAME=$(curl -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/project/project-id)
+              export TOKEN=$(curl -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token | jq .access_token -r)
 
-              registry resolve projects/${REGISTRY_PROJECT_NAME}/locations/global/artifacts/registry-protoc-gen-doc \
-                --registry.token=$TOKEN --registry.address=${REGISTRY_ADDRESS}
+              registry config set registry.address $REGISTRY_ADDRESS 
+              registry config set registry.insecure 0 
+              registry config set registry.project $REGISTRY_PROJECT_NAME 
+              registry config set registry.location global 
+              registry config set registry.token $TOKEN 
+
+              registry resolve artifacts/registry-protoc-gen-doc
 
               rc=$(echo $?)
               exit $rc

--- a/containers/registry-protoc-gen-doc/registry-protoc-gen-doc-controller.yaml
+++ b/containers/registry-protoc-gen-doc/registry-protoc-gen-doc-controller.yaml
@@ -51,6 +51,7 @@ spec:
           containers:
           - name: registry-protoc-gen-doc
             image: ghcr.io/apigee/registry-protoc-gen-doc:main
+            imagePullPolicy: Always
             env:
             - name: REGISTRY_ADDRESS
               value: "apigeeregistry.googleapis.com:443"
@@ -60,13 +61,15 @@ spec:
             - |
               export REGISTRY_PROJECT_NAME=$(curl -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/project/project-id)
               export TOKEN=$(curl -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token | jq .access_token -r)
+              echo $TOKEN > /tmp/registry-token
 
-              registry config set registry.address $REGISTRY_ADDRESS 
-              registry config set registry.insecure 0 
-              registry config set registry.project $REGISTRY_PROJECT_NAME 
-              registry config set registry.location global 
-              registry config set registry.token $TOKEN 
-
+              registry config configurations create default \
+                --registry.address=$REGISTRY_ADDRESS \
+                --registry.insecure=0 \
+                --registry.project=$REGISTRY_PROJECT_NAME \
+                --registry.location=global
+              registry config set token-source "cat /tmp/registry-token"
+              
               registry resolve artifacts/registry-protoc-gen-doc
 
               rc=$(echo $?)

--- a/containers/registry-protoc-gen-doc/registry-protoc-gen-doc-manifest.yaml
+++ b/containers/registry-protoc-gen-doc/registry-protoc-gen-doc-manifest.yaml
@@ -17,4 +17,4 @@ generated_resources:
   dependencies:
   - pattern: $resource.spec
     filter: "mime_type.contains('protobuf')"
-  action: "/doc-gen.sh $resource.spec grpc-docs"
+  action: "/doc-gen.sh $resource.spec grpc-docs /googleapis-common-protos"

--- a/containers/registry-protoc-gen-doc/registry-protoc-gen-doc-manifest.yaml
+++ b/containers/registry-protoc-gen-doc/registry-protoc-gen-doc-manifest.yaml
@@ -1,0 +1,20 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+id: registry-protoc-gen-doc
+generated_resources:
+- pattern: apis/-/versions/-/specs/-/artifacts/grpc-doc-url
+  dependencies:
+  - pattern: $resource.spec
+    filter: "mime_type.contains('protobuf')"
+  action: "/doc-gen.sh $resource.spec grpc-docs"

--- a/containers/registry-spec-renderer/index.js
+++ b/containers/registry-spec-renderer/index.js
@@ -17,10 +17,12 @@ const express = require('express')
 const fs = require("fs");
 const handlebars = require("handlebars");
 const {RegistryClient} = require("@google-cloud/apigee-registry");
+const {Storage} = require('@google-cloud/storage');
 const {credentials} = require("@grpc/grpc-js");
 const jsYaml = require('js-yaml');
 const {parseURL} = require("whatwg-url");
 const cors = require('cors')
+const storage = new Storage();
 
 var client_options = {};
 if (process.env.APG_REGISTRY_INSECURE
@@ -30,6 +32,8 @@ if (process.env.APG_REGISTRY_INSECURE
 
 const OPENAPI_MOCK_ENDPOINT = process.env.OPENAPI_MOCK_ENDPOINT;
 const GRAPHQL_MOCK_ENDPOINT = process.env.GRAPHQL_MOCK_ENDPOINT;
+const GRPC_DOC_ARTIFACT_NAME = process.env.GRPC_DOC_ARTIFACT_NAME
+    || 'grpc-doc-url';
 
 if (process.env.APG_REGISTRY_ADDRESS) {
   items = process.env.APG_REGISTRY_ADDRESS.split(":");
@@ -86,20 +90,56 @@ function renderTemplate(res, apiFormat, spec_name) {
         api_endpoint = GRAPHQL_MOCK_ENDPOINT + "/" + spec_name
       }
       break;
+    case "grpc":
+      renderer_template = "grpc_markdown";
+      break
     default:
       renderer_template = "spec_file"
       break;
   }
   spec_url = "/spec/" + apiFormat + "/" + spec_name + (api_endpoint
       ? "?endpoint_uri=" + encodeURI(api_endpoint) : "");
-  if (renderer_template != "spec_file") {
+  if (renderer_template == 'grpc_markdown') {
+    /**
+     * For GRPC documentation, we expect the HTML markup file to be
+     * generated and stored in GCS. The URL to the GCS object will be
+     * stored as an artifact on the spec object.
+     */
+    client.getArtifact({
+      name: spec_name + '/artifacts/' + GRPC_DOC_ARTIFACT_NAME
+    }, (err, artifact) => {
+      client.getArtifactContents({
+        name: spec_name + '/artifacts/' + GRPC_DOC_ARTIFACT_NAME
+      }, async (err, artifact_content) => {
+        if (err) {
+          res.sendStatus(500);
+          res.send("Error retrieving documentation for " + spec_name);
+          res.end();
+        } else {
+          let artifact_url = artifact_content.data.toString().trim();
+          let parsedUrl = parseURL(artifact_url);
+          if (parsedUrl.host == 'storage.googleapis.com') {
+            let bucket = parsedUrl.path.shift();
+            let contents = await storage.bucket(bucket).file(
+                parsedUrl.path.join("/")).download();
+            res.setHeader("content-type", "text/html");
+            res.send(contents[0].toString()).end();
+          } else {
+            res.redirect(artifact_url);
+          }
+        }
+      })
+    });
+
+  } else if (renderer_template != "spec_file") {
     res.setHeader("content-type", "text/html; charset=UTF-8");
     hbstemplate = handlebars.compile(renderer_template);
     res.send(hbstemplate({specUrl: spec_url, apiEndpoint: api_endpoint}));
+    res.end();
   } else {
     res.redirect(spec_url);
+    res.end();
   }
-  res.end();
 }
 
 function getAPIFormat(text) {
@@ -110,8 +150,8 @@ function getAPIFormat(text) {
     apiFormat = 'asyncapi';
   } else if (text.includes("discovery")) {
     apiFormat = 'discovery';
-  } else if (text.includes("proto")) {
-    apiFormat = 'proto';
+  } else if (text.includes("protobuf")) {
+    apiFormat = 'grpc';
   } else if (text.includes("graphql")) {
     apiFormat = 'graphql';
   }

--- a/containers/registry-spec-renderer/index.js
+++ b/containers/registry-spec-renderer/index.js
@@ -112,8 +112,8 @@ function renderTemplate(res, apiFormat, spec_name) {
         name: spec_name + '/artifacts/' + GRPC_DOC_ARTIFACT_NAME
       }, async (err, artifact_content) => {
         if (err) {
+          console.error("Error retrieving documentation for " + spec_name);
           res.sendStatus(500);
-          res.send("Error retrieving documentation for " + spec_name);
           res.end();
         } else {
           let artifact_url = artifact_content.data.toString().trim();

--- a/containers/registry-spec-renderer/package.json
+++ b/containers/registry-spec-renderer/package.json
@@ -12,6 +12,7 @@
     "@asyncapi/react-component": "^0.24.23",
     "@asyncapi/web-component": "^0.24.23",
     "@google-cloud/apigee-registry": "^0.2.1",
+    "@google-cloud/storage": "^6.5.4",
     "@graphql-tools/load": "^7.7.7",
     "@graphql-tools/mock": "^8.7.6",
     "@webcomponents/webcomponentsjs": "^2.6.0",


### PR DESCRIPTION
1. Custom controller listens for changes to Specs (of type protobuf) and generates HTML using protoc-doc-gen plugin.
2. Uploads the generated HTML to google storage bucket and reference to the GCS item is stored as an artifact