### PR TITLE
Add `export csv` subcommand to registry-experimental

### DIFF
--- a/cmd/registry-experimental/cmd/export/csv.go
+++ b/cmd/registry-experimental/cmd/export/csv.go
@@ -1,0 +1,110 @@
+// Copyright 2021 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package export
+
+import (
+	"encoding/csv"
+	"fmt"
+
+	"github.com/apigee/registry/cmd/registry/core"
+	"github.com/apigee/registry/log"
+	"github.com/apigee/registry/pkg/connection"
+	"github.com/apigee/registry/rpc"
+	"github.com/apigee/registry/server/registry/names"
+	"github.com/spf13/cobra"
+)
+
+type exportCSVRow struct {
+	ApiID        string
+	VersionID    string
+	SpecID       string
+	ContentsPath string
+}
+
+func csvCommand() *cobra.Command {
+	var filter string
+	cmd := &cobra.Command{
+		Use:   "csv [--filter expression] parent ...",
+		Short: "Export API specs to a CSV file",
+		Args: func(cmd *cobra.Command, args []string) error {
+			c, err := connection.ActiveConfig()
+			if err != nil {
+				return fmt.Errorf("Failed to get config: %s", err)
+			}
+			for _, parent := range args {
+				parent = c.FQName(parent)
+				if _, err := names.ParseVersion(parent); err != nil {
+					return fmt.Errorf("invalid parent argument %q", parent)
+				}
+			}
+
+			return nil
+		},
+		Run: func(cmd *cobra.Command, args []string) {
+			ctx := cmd.Context()
+			client, err := connection.NewRegistryClient(ctx)
+			if err != nil {
+				log.FromContext(ctx).WithError(err).Fatal("Failed to get client")
+			}
+
+			rows := make([]exportCSVRow, 0)
+			for _, parent := range args {
+				version, err := names.ParseVersion(parent)
+				if err != nil {
+					log.Debugf(ctx, "Failed to parse version name %q: skipping spec row", parent)
+					return
+				}
+
+				err = core.ListSpecs(ctx, client, version.Spec(""), filter, func(spec *rpc.ApiSpec) error {
+					name, err := names.ParseSpec(spec.GetName())
+					if err != nil {
+						log.Debugf(ctx, "Failed to parse spec name %q: skipping spec row", spec.GetName())
+						return nil
+					}
+
+					rows = append(rows, exportCSVRow{
+						ApiID:        name.ApiID,
+						VersionID:    name.VersionID,
+						SpecID:       name.SpecID,
+						ContentsPath: fmt.Sprintf("$APG_REGISTRY_ADDRESS/%s", spec.GetName()),
+					})
+					return nil
+				})
+				if err != nil {
+					log.FromContext(ctx).WithError(err).Fatalf("Failed to list specs")
+				}
+			}
+
+			w := csv.NewWriter(cmd.OutOrStdout())
+			if err := w.Write([]string{"api_id", "version_id", "spec_id", "contents_path"}); err != nil {
+				log.FromContext(ctx).WithError(err).Fatalf("Failed to write CSV header")
+			}
+
+			for _, row := range rows {
+				if err := w.Write([]string{row.ApiID, row.VersionID, row.SpecID, row.ContentsPath}); err != nil {
+					log.FromContext(ctx).WithError(err).Fatalf("Failed to write CSV row %v", row)
+				}
+			}
+
+			w.Flush()
+			if err := w.Error(); err != nil {
+				log.FromContext(ctx).WithError(err).Fatalf("Failed to flush writes to output")
+			}
+		},
+	}
+
+	cmd.Flags().StringVar(&filter, "filter", "", "Filter selected resources")
+	return cmd
+}

--- a/cmd/registry-experimental/cmd/export/csv_test.go
+++ b/cmd/registry-experimental/cmd/export/csv_test.go
@@ -1,0 +1,131 @@
+// Copyright 2021 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package export
+
+import (
+	"bytes"
+	"context"
+	"encoding/csv"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/apigee/registry/pkg/connection"
+	"github.com/apigee/registry/rpc"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestExportCSV(t *testing.T) {
+	ctx := context.Background()
+	client, err := connection.NewRegistryClient(ctx)
+	if err != nil {
+		t.Fatalf("Setup: Failed to create client: %s", err)
+	}
+	adminClient, err := connection.NewAdminClient(ctx)
+	if err != nil {
+		t.Fatalf("Setup: Failed to create client: %s", err)
+	}
+
+	const (
+		projectID = "export-csv-test-project"
+		apiID     = "my-api"
+		versionID = "v1"
+		specID    = "my-spec"
+	)
+
+	// Setup
+	err = adminClient.DeleteProject(ctx, &rpc.DeleteProjectRequest{
+		Name:  "projects/" + projectID,
+		Force: true,
+	})
+	if err != nil && status.Code(err) != codes.NotFound {
+		t.Fatalf("Setup: Failed to delete test project: %s", err)
+	}
+
+	project, err := adminClient.CreateProject(ctx, &rpc.CreateProjectRequest{
+		ProjectId: projectID,
+		Project:   &rpc.Project{},
+	})
+	if err != nil {
+		t.Fatalf("Setup: Failed to create project: %s", err)
+	}
+
+	api, err := client.CreateApi(ctx, &rpc.CreateApiRequest{
+		Parent: project.GetName() + "/locations/global",
+		ApiId:  apiID,
+		Api:    &rpc.Api{},
+	})
+	if err != nil {
+		t.Fatalf("Setup: Failed to create api: %s", err)
+	}
+
+	version, err := client.CreateApiVersion(ctx, &rpc.CreateApiVersionRequest{
+		Parent:       api.GetName(),
+		ApiVersionId: versionID,
+		ApiVersion:   &rpc.ApiVersion{},
+	})
+	if err != nil {
+		t.Fatalf("Setup: Failed to create version: %s", err)
+	}
+
+	spec, err := client.CreateApiSpec(ctx, &rpc.CreateApiSpecRequest{
+		Parent:    version.GetName(),
+		ApiSpecId: specID,
+		ApiSpec:   &rpc.ApiSpec{},
+	})
+	if err != nil {
+		t.Fatalf("Setup: Failed to create spec: %s", err)
+	}
+
+	// Execute
+	cmd := Command()
+	out := bytes.NewBuffer(make([]byte, 0))
+	args := []string{"csv", version.GetName()}
+	cmd.SetOut(out)
+	cmd.SetErr(io.Discard)
+	cmd.SetArgs(args)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() with args %v returned error: %s", args, err)
+	}
+
+	// Verify
+	var (
+		expectedHeader = []string{"api_id", "version_id", "spec_id", "contents_path"}
+		expectedRow    = []string{apiID, versionID, specID, fmt.Sprintf("$APG_REGISTRY_ADDRESS/%s", spec.GetName())}
+	)
+
+	r := csv.NewReader(out)
+	header, err := r.Read()
+	if err != nil {
+		t.Fatalf("Failed to read CSV header: %s", err)
+	}
+
+	sortStrings := cmpopts.SortSlices(func(a, b string) bool { return a < b })
+	if diff := cmp.Diff(expectedHeader, header, sortStrings); diff != "" {
+		t.Errorf("Command printed unexpected header (-want +got):\n%s", diff)
+	}
+
+	row, err := r.Read()
+	if err != nil {
+		t.Fatalf("Failed to read expected CSV row: %s", err)
+	}
+
+	if diff := cmp.Diff(expectedRow, row, sortStrings); diff != "" {
+		t.Errorf("Command printed unexpected row (-want +got):\n%s", diff)
+	}
+}

--- a/cmd/registry-experimental/cmd/export/export.go
+++ b/cmd/registry-experimental/cmd/export/export.go
@@ -1,0 +1,30 @@
+// Copyright 2020 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package export
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func Command() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "export",
+		Short: "Export resources from the API Registry",
+	}
+
+	cmd.AddCommand(csvCommand())
+
+	return cmd
+}

--- a/cmd/registry-experimental/cmd/export/export_test.go
+++ b/cmd/registry-experimental/cmd/export/export_test.go
@@ -1,0 +1,29 @@
+// Copyright 2022 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package export
+
+import (
+	"testing"
+
+	"github.com/apigee/registry/pkg/connection/grpctest"
+	"github.com/apigee/registry/server/registry"
+)
+
+// TestMain will set up a local RegistryServer and grpc.Server for all
+// tests in this package if APG_REGISTRY_ADDRESS env var is not set
+// for the client.
+func TestMain(m *testing.M) {
+	grpctest.TestMain(m, registry.Config{})
+}

--- a/cmd/registry-experimental/cmd/root.go
+++ b/cmd/registry-experimental/cmd/root.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/apigee/registry-experimental/cmd/registry-experimental/cmd/compute"
+	"github.com/apigee/registry-experimental/cmd/registry-experimental/cmd/export"
 	"github.com/apigee/registry-experimental/cmd/registry-experimental/cmd/search"
 	"github.com/apigee/registry-experimental/cmd/registry-experimental/cmd/wipeout"
 	"github.com/apigee/registry/log"
@@ -41,6 +42,7 @@ func Command(ctx context.Context) *cobra.Command {
 	})
 
 	cmd.AddCommand(compute.Command(ctx))
+	cmd.AddCommand(export.Command())
 	cmd.AddCommand(search.Command(ctx))
 	cmd.AddCommand(wipeout.Command(ctx))
 


### PR DESCRIPTION
Moving this from the main `registry` tool for possible future evaluation.