### PR TITLE
Add new "registry-experimental compute summary" command.

### DIFF
--- a/cmd/registry-experimental/cmd/compute/compute.go
+++ b/cmd/registry-experimental/cmd/compute/compute.go
@@ -17,6 +17,7 @@ package compute
 import (
 	"context"
 
+	"github.com/apigee/registry-experimental/cmd/registry-experimental/cmd/compute/summary"
 	"github.com/spf13/cobra"
 )
 
@@ -28,6 +29,7 @@ func Command(ctx context.Context) *cobra.Command {
 
 	cmd.AddCommand(descriptorCommand(ctx))
 	cmd.AddCommand(searchIndexCommand(ctx))
+	cmd.AddCommand(summary.Command())
 
 	cmd.PersistentFlags().String("filter", "", "Filter selected resources")
 	return cmd

--- a/cmd/registry-experimental/cmd/compute/summary/summary.go
+++ b/cmd/registry-experimental/cmd/compute/summary/summary.go
@@ -1,0 +1,146 @@
+// Copyright 2023 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package summary
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/apigee/registry/cmd/registry/core"
+	"github.com/apigee/registry/pkg/connection"
+	"github.com/apigee/registry/pkg/names"
+	"github.com/apigee/registry/pkg/visitor"
+	"github.com/apigee/registry/rpc"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
+)
+
+func Command() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "summary PATTERN",
+		Short: "Compute summary metrics of resources",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			c, err := connection.ActiveConfig()
+			if err != nil {
+				return err
+			}
+			pattern := c.FQName(args[0])
+			filter, err := cmd.Flags().GetString("filter")
+			if err != nil {
+				return err
+			}
+			adminClient, err := connection.NewAdminClientWithSettings(ctx, c)
+			if err != nil {
+				return err
+			}
+			registryClient, err := connection.NewRegistryClientWithSettings(ctx, c)
+			if err != nil {
+				return err
+			}
+			v := &summaryVisitor{
+				ctx:            ctx,
+				registryClient: registryClient,
+			}
+			return visitor.Visit(ctx, v, visitor.VisitorOptions{
+				RegistryClient:  registryClient,
+				AdminClient:     adminClient,
+				Pattern:         pattern,
+				Filter:          filter,
+				ImplicitProject: &rpc.Project{Name: "projects/implicit"},
+			})
+		},
+	}
+	cmd.Flags().String("filter", "", "Filter selected resources")
+	cmd.Flags().Int("jobs", 10, "Number of actions to perform concurrently")
+	return cmd
+}
+
+type summaryVisitor struct {
+	visitor.Unsupported
+	ctx            context.Context
+	registryClient connection.RegistryClient
+	adminClient    connection.AdminClient
+}
+
+type Summary struct {
+	ApiCount        int `yaml:"apiCount,omitempty"`
+	VersionCount    int `yaml:"versionCount,omitempty"`
+	SpecCount       int `yaml:"specCount,omitempty"`
+	DeploymentCount int `yaml:"deploymentCount,omitempty"`
+}
+
+func (v *summaryVisitor) ProjectHandler() visitor.ProjectHandler {
+	return func(message *rpc.Project) error {
+		fmt.Printf("%s\n", message.Name)
+		projectName, err := names.ParseProject(message.Name)
+		if err != nil {
+			return err
+		}
+		apiCount := 0
+		if err := visitor.ListAPIs(v.ctx, v.registryClient,
+			projectName.Api("-"), "",
+			func(api *rpc.Api) error {
+				apiCount++
+				return nil
+			}); err != nil {
+			return err
+		}
+		versionCount := 0
+		if err := visitor.ListVersions(v.ctx, v.registryClient,
+			projectName.Api("-").Version("-"), "",
+			func(message *rpc.ApiVersion) error {
+				versionCount++
+				return nil
+			}); err != nil {
+			return err
+		}
+		specCount := 0
+		if err := visitor.ListSpecs(v.ctx, v.registryClient,
+			projectName.Api("-").Version("-").Spec("-"), "", false,
+			func(message *rpc.ApiSpec) error {
+				specCount++
+				return nil
+			}); err != nil {
+			return err
+		}
+		deploymentCount := 0
+		if err := visitor.ListDeployments(v.ctx, v.registryClient,
+			projectName.Api("-").Deployment("-"), "",
+			func(message *rpc.ApiDeployment) error {
+				deploymentCount++
+				return nil
+			}); err != nil {
+			return err
+		}
+		summary := &Summary{
+			ApiCount:        apiCount,
+			VersionCount:    versionCount,
+			SpecCount:       specCount,
+			DeploymentCount: deploymentCount,
+		}
+		bytes, err := yaml.Marshal(summary)
+		if err != nil {
+			return err
+		}
+		artifact := &rpc.Artifact{
+			Name:     projectName.Artifact("summary").String(),
+			MimeType: "application/yaml;type=Summary",
+			Contents: bytes,
+		}
+		return core.SetArtifact(v.ctx, v.registryClient, artifact)
+	}
+}

--- a/cmd/registry-experimental/cmd/compute/summary/summary_test.go
+++ b/cmd/registry-experimental/cmd/compute/summary/summary_test.go
@@ -1,0 +1,75 @@
+// Copyright 2023 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package summary
+
+import (
+	"context"
+	"testing"
+
+	"github.com/apigee/registry/pkg/connection/grpctest"
+	"github.com/apigee/registry/rpc"
+	"github.com/apigee/registry/server/registry"
+	"github.com/apigee/registry/server/registry/test/seeder"
+	"gopkg.in/yaml.v2"
+)
+
+func TestMain(m *testing.M) {
+	grpctest.TestMain(m, registry.Config{})
+}
+
+func TestSummary(t *testing.T) {
+	ctx := context.Background()
+	registryClient, _ := grpctest.SetupRegistry(ctx, t, "summary-test",
+		[]seeder.RegistryResource{
+			&rpc.Artifact{
+				Name: "projects/summary-test/locations/global/apis/a1/versions/v1/specs/s1/artifacts/x1",
+			},
+			&rpc.Artifact{
+				Name: "projects/summary-test/locations/global/apis/a2/versions/v1/specs/s1/artifacts/x1",
+			},
+			&rpc.Artifact{
+				Name: "projects/summary-test/locations/global/apis/a2/versions/v1/specs/s2/artifacts/x1",
+			},
+			&rpc.Artifact{
+				Name: "projects/summary-test/locations/global/apis/a2/deployments/d1/artifacts/x1",
+			},
+		})
+	cmd := Command()
+	cmd.SetArgs([]string{"projects/summary-test"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() with args %+v returned error: %s", cmd.Args, err)
+	}
+	contents, err := registryClient.GetArtifactContents(ctx,
+		&rpc.GetArtifactContentsRequest{Name: "projects/summary-test/locations/global/artifacts/summary"})
+	if err != nil {
+		t.Fatalf("Artifact could not be read %s", err)
+	}
+	var s Summary
+	if err := yaml.Unmarshal(contents.Data, &s); err != nil {
+		t.Fatalf("Artifact could not be parsed %s", err)
+	}
+	if s.ApiCount != 2 {
+		t.Errorf("Incorrect API count, expected 2, got %d", s.ApiCount)
+	}
+	if s.VersionCount != 2 {
+		t.Errorf("Incorrect version count, expected 2, got %d", s.VersionCount)
+	}
+	if s.SpecCount != 3 {
+		t.Errorf("Incorrect spec count, expected 3, got %d", s.SpecCount)
+	}
+	if s.DeploymentCount != 1 {
+		t.Errorf("Incorrect deployment count, expected 1, got %d", s.DeploymentCount)
+	}
+}


### PR DESCRIPTION
This adds a fairly trivial subcommand that computes counts of the numbers of APIs, versions, specs, and deployments in a project and stores the result in a YAML artifact under the "summary" id. It benefits from and illustrates the use of `visitor.Visit` and tests use `grpctest.SetupRegistry`, which I have to say is a huge step forward.

This currently only supports project arguments, but in the future it might be worth expanding this to apply to other resources and annotate them with counts of their subresources.

Artifact counts are omitted because they would be expensive to compute, but we might want to add those in the future.