### PR TITLE
Update graphql README and tests for new server configuration.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -40,15 +40,11 @@ jobs:
         version: v1.45
         args: --timeout 5m0s
 
-    - name: Install
-      run: go install ./...
+    - name: Install the registry tool
+      run: go install github.com/apigee/registry/cmd/registry@latest  
 
-    - name: Install registry-server
-      run: go install github.com/apigee/registry/cmd/registry-server@latest  
+    - name: Create default registry configuration
+      run: registry config configurations create localhost --registry.address='localhost:8080'
 
     - name: Test everything with SQLite
-      run: registry-server & make test
-      env:
-        APG_REGISTRY_ADDRESS: localhost:8080 
-        APG_REGISTRY_AUDIENCES: http://localhost:8080
-        APG_REGISTRY_INSECURE: 1
+      run: make test

--- a/cmd/registry-graphql/README.md
+++ b/cmd/registry-graphql/README.md
@@ -14,15 +14,18 @@ provide access to spec revisions or artifact values.
 
 ## Invocation
 
-Just run the `registry-graphql` program. It uses the `APG_*` environment
-variables to connect to a Registry API server. Because it serves static files,
-it should be run in the same directory as its source files.
+Just run the `registry-graphql` program. It uses the
+[registry](https://github.com/apigee/registry) project's
+[pkg/connection](https://github.com/apigee/registry/tree/main/pkg/connection) to
+get an authenticated connection to a Registry API server. Because it serves
+static files, it should be run in the same directory as its source files.
 
-If you're building a React or other browser-hosted client application, you
-can use the `-cors-allow-origin` flag to allow CORS requests while you are
+If you're building a React or other browser-hosted client application, you can
+use the `-cors-allow-origin` flag to allow CORS requests while you are
 developing your app. This allows you to specify a single allowed origin, which
 can include `*`, which allows all CORS requests. Take care to quote the `*` to
 avoid shell expansion:
+
 ```
 registry-graphql -cors-allow-origin '*'
 ```

--- a/cmd/registry-graphql/graphql/graphql_test.go
+++ b/cmd/registry-graphql/graphql/graphql_test.go
@@ -22,11 +22,17 @@ import (
 	"testing"
 
 	"github.com/apigee/registry/pkg/connection"
+	"github.com/apigee/registry/pkg/connection/grpctest"
 	"github.com/apigee/registry/rpc"
+	"github.com/apigee/registry/server/registry"
 	"github.com/graphql-go/graphql"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
+
+func TestMain(m *testing.M) {
+	grpctest.TestMain(m, registry.Config{})
+}
 
 func unavailable(err error) bool {
 	if err == nil {


### PR DESCRIPTION
This updates the testing of the graphql demo to use `grpctest.TestMain()` to create a temporary test server, eliminating the need to run a test server in CI (and that test server is removed).

Fixes #141 