### PR TITLE
Update to HEAD of registry main to pick up changes to pkg exports.

### DIFF
--- a/cmd/apigee-export/apis.go
+++ b/cmd/apigee-export/apis.go
@@ -20,8 +20,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/apigee/registry/pkg/encoding"
 	"github.com/apigee/registry/pkg/log"
-	"github.com/apigee/registry/pkg/models"
 	"github.com/spf13/cobra"
 	"google.golang.org/api/apigee/v1"
 	"gopkg.in/yaml.v2"
@@ -49,11 +49,11 @@ func exportApis(cmd *cobra.Command, args []string) {
 	}
 
 	for _, proxy := range apis {
-		api := &models.Api{
-			Header: models.Header{
+		api := &encoding.Api{
+			Header: encoding.Header{
 				ApiVersion: "apigeeregistry/v1",
 				Kind:       "API",
-				Metadata: models.Metadata{
+				Metadata: encoding.Metadata{
 					Name: clean(proxy.Name),
 					Annotations: map[string]string{
 						"apigee-organization": org,
@@ -61,7 +61,7 @@ func exportApis(cmd *cobra.Command, args []string) {
 					},
 				},
 			},
-			Data: models.ApiData{
+			Data: encoding.ApiData{
 				DisplayName: proxy.Name,
 			},
 		}
@@ -104,7 +104,7 @@ func apis(ctx context.Context, org string) ([]*apigee.GoogleCloudApigeeV1ApiProx
 	return resp.Proxies, nil
 }
 
-func annotateAPI(api *models.Api) {
+func annotateAPI(api *encoding.Api) {
 	if api.Header.Metadata.Labels == nil {
 		api.Header.Metadata.Labels = make(map[string]string)
 	}
@@ -112,25 +112,25 @@ func annotateAPI(api *models.Api) {
 	api.Header.Metadata.Labels["apihub-style"] = "apihub-openapi"
 	api.Header.Metadata.Labels["apihub-target-users"] = "team_internal_partner_public"
 	api.Header.Metadata.Labels["apihub-team"] = "demo-customer"
-	api.Data.ApiVersions = []*models.ApiVersion{{
-		Header: models.Header{
+	api.Data.ApiVersions = []*encoding.ApiVersion{{
+		Header: encoding.Header{
 			ApiVersion: "apigeeregistry/v1",
 			Kind:       "Version",
-			Metadata: models.Metadata{
+			Metadata: encoding.Metadata{
 				Name: "v1",
 				Annotations: map[string]string{
 					"apihub-end-of-life-type": "apihub-unknown",
 				},
 			},
 		},
-		Data: models.ApiVersionData{
+		Data: encoding.ApiVersionData{
 			DisplayName: "v1",
 			State:       "production",
-			ApiSpecs: []*models.ApiSpec{{
-				Header: models.Header{
+			ApiSpecs: []*encoding.ApiSpec{{
+				Header: encoding.Header{
 					ApiVersion: "apigeeregistry/v1",
 					Kind:       "Spec",
-					Metadata: models.Metadata{
+					Metadata: encoding.Metadata{
 						Name: "unknown",
 					},
 				},

--- a/cmd/apigee-export/deployments.go
+++ b/cmd/apigee-export/deployments.go
@@ -20,8 +20,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/apigee/registry/pkg/encoding"
 	"github.com/apigee/registry/pkg/log"
-	"github.com/apigee/registry/pkg/models"
 	"github.com/spf13/cobra"
 	"google.golang.org/api/apigee/v1"
 	"gopkg.in/yaml.v2"
@@ -54,11 +54,11 @@ func exportDeployments(cmd *cobra.Command, args []string) {
 	}
 
 	for _, dep := range deps {
-		api := &models.Api{
-			Header: models.Header{
+		api := &encoding.Api{
+			Header: encoding.Header{
 				ApiVersion: "apigeeregistry/v1",
 				Kind:       "API",
-				Metadata: models.Metadata{
+				Metadata: encoding.Metadata{
 					Name: clean(dep.ApiProxy),
 					Annotations: map[string]string{
 						"apigee-organization": org,
@@ -66,9 +66,9 @@ func exportDeployments(cmd *cobra.Command, args []string) {
 					},
 				},
 			},
-			Data: models.ApiData{
+			Data: encoding.ApiData{
 				DisplayName:    dep.ApiProxy,
-				ApiDeployments: make([]*models.ApiDeployment, 0, len(deps)),
+				ApiDeployments: make([]*encoding.ApiDeployment, 0, len(deps)),
 			},
 		}
 
@@ -85,11 +85,11 @@ func exportDeployments(cmd *cobra.Command, args []string) {
 				continue
 			}
 
-			api.Data.ApiDeployments = append(api.Data.ApiDeployments, &models.ApiDeployment{
-				Header: models.Header{
+			api.Data.ApiDeployments = append(api.Data.ApiDeployments, &encoding.ApiDeployment{
+				Header: encoding.Header{
 					ApiVersion: "apigeeregistry/v1",
 					Kind:       "Deployment",
-					Metadata: models.Metadata{
+					Metadata: encoding.Metadata{
 						Name: clean(hostname),
 						Annotations: map[string]string{
 							"apigee-organization":   org,
@@ -99,7 +99,7 @@ func exportDeployments(cmd *cobra.Command, args []string) {
 						},
 					},
 				},
-				Data: models.ApiDeploymentData{
+				Data: encoding.ApiDeploymentData{
 					DisplayName: dep.Environment,
 					EndpointURI: hostname,
 				},

--- a/cmd/artifact-server/main.go
+++ b/cmd/artifact-server/main.go
@@ -21,8 +21,12 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/apigee/registry/cmd/registry/types"
+	"github.com/apigee/registry/pkg/application/apihub"
+	"github.com/apigee/registry/pkg/application/controller"
+	"github.com/apigee/registry/pkg/application/scoring"
+	"github.com/apigee/registry/pkg/application/style"
 	"github.com/apigee/registry/pkg/connection"
+	"github.com/apigee/registry/pkg/mime"
 	"github.com/apigee/registry/rpc"
 	"golang.org/x/exp/slices"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -42,20 +46,20 @@ var messageTypes map[string]proto.Message = map[string]proto.Message{
 	"gnostic.metrics.Vocabulary":                                 &metrics.Vocabulary{},
 	"gnostic.openapiv2.Document":                                 &oas2.Document{},
 	"gnostic.openapiv3.Document":                                 &oas3.Document{},
-	"google.cloud.apigeeregistry.v1.style.Lint":                  &rpc.Lint{},
-	"google.cloud.apigeeregistry.v1.style.LintStats":             &rpc.LintStats{},
-	"google.cloud.apigeeregistry.v1.apihub.DisplaySettings":      &rpc.DisplaySettings{},
-	"google.cloud.apigeeregistry.v1.apihub.Lifecycle":            &rpc.Lifecycle{},
-	"google.cloud.apigeeregistry.v1.apihub.ReferenceList":        &rpc.ReferenceList{},
-	"google.cloud.apigeeregistry.v1.apihub.TaxonomyList":         &rpc.TaxonomyList{},
-	"google.cloud.apigeeregistry.v1.controller.Manifest":         &rpc.Manifest{},
-	"google.cloud.apigeeregistry.v1.controller.Receipt":          &rpc.Receipt{},
-	"google.cloud.apigeeregistry.v1.scoring.Score":               &rpc.Score{},
-	"google.cloud.apigeeregistry.v1.scoring.ScoreCard":           &rpc.ScoreCard{},
-	"google.cloud.apigeeregistry.v1.scoring.ScoreCardDefinition": &rpc.ScoreCardDefinition{},
-	"google.cloud.apigeeregistry.v1.scoring.ScoreDefinition":     &rpc.ScoreDefinition{},
-	"google.cloud.apigeeregistry.v1.style.ConformanceReport":     &rpc.ConformanceReport{},
-	"google.cloud.apigeeregistry.v1.style.StyleGuide":            &rpc.StyleGuide{},
+	"google.cloud.apigeeregistry.v1.style.Lint":                  &style.Lint{},
+	"google.cloud.apigeeregistry.v1.style.LintStats":             &style.LintStats{},
+	"google.cloud.apigeeregistry.v1.apihub.DisplaySettings":      &apihub.DisplaySettings{},
+	"google.cloud.apigeeregistry.v1.apihub.Lifecycle":            &apihub.Lifecycle{},
+	"google.cloud.apigeeregistry.v1.apihub.ReferenceList":        &apihub.ReferenceList{},
+	"google.cloud.apigeeregistry.v1.apihub.TaxonomyList":         &apihub.TaxonomyList{},
+	"google.cloud.apigeeregistry.v1.controller.Manifest":         &controller.Manifest{},
+	"google.cloud.apigeeregistry.v1.controller.Receipt":          &controller.Receipt{},
+	"google.cloud.apigeeregistry.v1.scoring.Score":               &scoring.Score{},
+	"google.cloud.apigeeregistry.v1.scoring.ScoreCard":           &scoring.ScoreCard{},
+	"google.cloud.apigeeregistry.v1.scoring.ScoreCardDefinition": &scoring.ScoreCardDefinition{},
+	"google.cloud.apigeeregistry.v1.scoring.ScoreDefinition":     &scoring.ScoreDefinition{},
+	"google.cloud.apigeeregistry.v1.style.ConformanceReport":     &style.ConformanceReport{},
+	"google.cloud.apigeeregistry.v1.style.StyleGuide":            &style.StyleGuide{},
 	"google.protobuf.FileDescriptorSet":                          &descriptorpb.FileDescriptorSet{},
 }
 
@@ -76,7 +80,7 @@ func handleRequest(w http.ResponseWriter, req *http.Request) {
 		fmt.Fprintf(w, "%s\n", contents.GetData())
 		return
 	}
-	messageType, err := types.MessageTypeForMimeType(contents.GetContentType())
+	messageType, err := mime.MessageTypeForMimeType(contents.GetContentType())
 	if err != nil {
 		writeError(w, err, http.StatusInternalServerError)
 		return

--- a/cmd/registry-experimental/cmd/bleve/index.go
+++ b/cmd/registry-experimental/cmd/bleve/index.go
@@ -21,9 +21,9 @@ import (
 
 	"github.com/apigee/registry/cmd/registry/compress"
 	"github.com/apigee/registry/cmd/registry/tasks"
-	"github.com/apigee/registry/cmd/registry/types"
 	"github.com/apigee/registry/pkg/connection"
 	"github.com/apigee/registry/pkg/log"
+	"github.com/apigee/registry/pkg/mime"
 	"github.com/apigee/registry/pkg/names"
 	"github.com/apigee/registry/pkg/visitor"
 	"github.com/apigee/registry/rpc"
@@ -102,11 +102,11 @@ func (task *indexSpecTask) Run(ctx context.Context) error {
 	var message interface{}
 	switch {
 	case spec.GetMimeType() == "text/plain" ||
-		types.IsOpenAPIv2(spec.GetMimeType()) ||
-		types.IsOpenAPIv3(spec.GetMimeType()) ||
-		types.IsDiscovery(spec.GetMimeType()):
+		mime.IsOpenAPIv2(spec.GetMimeType()) ||
+		mime.IsOpenAPIv3(spec.GetMimeType()) ||
+		mime.IsDiscovery(spec.GetMimeType()):
 		message = map[string]string{spec.GetFilename(): string(data)}
-	case types.IsProto(spec.GetMimeType()):
+	case mime.IsProto(spec.GetMimeType()):
 		m, err := compress.UnzipArchiveToMap(data)
 		if err != nil {
 			return err

--- a/cmd/registry-experimental/cmd/compute/descriptor.go
+++ b/cmd/registry-experimental/cmd/compute/descriptor.go
@@ -25,9 +25,9 @@ import (
 
 	"github.com/apigee/registry/cmd/registry/compress"
 	"github.com/apigee/registry/cmd/registry/tasks"
-	"github.com/apigee/registry/cmd/registry/types"
 	"github.com/apigee/registry/pkg/connection"
 	"github.com/apigee/registry/pkg/log"
+	"github.com/apigee/registry/pkg/mime"
 	"github.com/apigee/registry/pkg/names"
 	"github.com/apigee/registry/pkg/visitor"
 	"github.com/apigee/registry/rpc"
@@ -105,25 +105,25 @@ func (task *computeDescriptorTask) Run(ctx context.Context) error {
 	subject := spec.GetName()
 	var typeURL string
 	var document proto.Message
-	if types.IsOpenAPIv2(spec.GetMimeType()) {
+	if mime.IsOpenAPIv2(spec.GetMimeType()) {
 		typeURL = "gnostic.openapiv2.Document"
 		document, err = oas2.ParseDocument(data)
 		if err != nil {
 			return err
 		}
-	} else if types.IsOpenAPIv3(spec.GetMimeType()) {
+	} else if mime.IsOpenAPIv3(spec.GetMimeType()) {
 		typeURL = "gnostic.openapiv3.Document"
 		document, err = oas3.ParseDocument(data)
 		if err != nil {
 			return err
 		}
-	} else if types.IsDiscovery(spec.GetMimeType()) {
+	} else if mime.IsDiscovery(spec.GetMimeType()) {
 		typeURL = "gnostic.discoveryv1.Document"
 		document, err = discovery.ParseDocument(data)
 		if err != nil {
 			return err
 		}
-	} else if types.IsProto(spec.GetMimeType()) && types.IsZipArchive(spec.GetMimeType()) {
+	} else if mime.IsProto(spec.GetMimeType()) && mime.IsZipArchive(spec.GetMimeType()) {
 		typeURL = "google.protobuf.FileDescriptorSet"
 		document, err = descriptorFromZippedProtos(ctx, spec.Name, data)
 		if err != nil {
@@ -140,7 +140,7 @@ func (task *computeDescriptorTask) Run(ctx context.Context) error {
 	// this will probably require some representation of compression type in the typeURL
 	artifact := &rpc.Artifact{
 		Name:     subject + "/artifacts/" + relation,
-		MimeType: types.MimeTypeForMessageType(typeURL),
+		MimeType: mime.MimeTypeForMessageType(typeURL),
 		Contents: messageData,
 	}
 	return visitor.SetArtifact(ctx, task.client, artifact)

--- a/cmd/registry-experimental/cmd/extract/extract.go
+++ b/cmd/registry-experimental/cmd/extract/extract.go
@@ -24,8 +24,8 @@ import (
 	"strings"
 
 	"github.com/apigee/registry/cmd/registry/compress"
-	"github.com/apigee/registry/cmd/registry/types"
 	"github.com/apigee/registry/pkg/connection"
+	"github.com/apigee/registry/pkg/mime"
 	"github.com/apigee/registry/pkg/names"
 	"github.com/apigee/registry/pkg/visitor"
 	"github.com/apigee/registry/rpc"
@@ -85,13 +85,13 @@ func (v *extractVisitor) SpecHandler() visitor.SpecHandler {
 			return err
 		}
 		bytes := spec.Contents
-		if types.IsGZipCompressed(spec.MimeType) {
+		if mime.IsGZipCompressed(spec.MimeType) {
 			bytes, err = compress.GUnzippedBytes(bytes)
 			if err != nil {
 				return err
 			}
 		}
-		if types.IsOpenAPIv2(spec.MimeType) || types.IsOpenAPIv3(spec.MimeType) {
+		if mime.IsOpenAPIv2(spec.MimeType) || mime.IsOpenAPIv3(spec.MimeType) {
 			var node yaml.Node
 			if err := yaml.Unmarshal(bytes, &node); err != nil {
 				return err
@@ -171,14 +171,14 @@ func (v *extractVisitor) SpecHandler() visitor.SpecHandler {
 			// Set the spec mimetype (this should not bump the revision!).
 			if openapi != nil || swagger != nil {
 				var compression string
-				if types.IsGZipCompressed(spec.MimeType) {
+				if mime.IsGZipCompressed(spec.MimeType) {
 					compression = "+gzip"
 				}
 				var mimeType string
 				if openapi != nil {
-					mimeType = types.OpenAPIMimeType(compression, *openapi)
+					mimeType = mime.OpenAPIMimeType(compression, *openapi)
 				} else if swagger != nil {
-					mimeType = types.OpenAPIMimeType(compression, *swagger)
+					mimeType = mime.OpenAPIMimeType(compression, *swagger)
 				}
 				specName, _ := names.ParseSpec(spec.Name)
 				_, err := v.registryClient.UpdateApiSpec(v.ctx,
@@ -194,7 +194,7 @@ func (v *extractVisitor) SpecHandler() visitor.SpecHandler {
 				}
 			}
 		}
-		if types.IsDiscovery(spec.MimeType) {
+		if mime.IsDiscovery(spec.MimeType) {
 			var node yaml.Node
 			if err := yaml.Unmarshal(bytes, &node); err != nil {
 				return err
@@ -258,7 +258,7 @@ func (v *extractVisitor) SpecHandler() visitor.SpecHandler {
 			}
 
 		}
-		if types.IsProto(spec.MimeType) {
+		if mime.IsProto(spec.MimeType) {
 			// create a tmp directory
 			root, err := os.MkdirTemp("", "extract-protos-")
 			if err != nil {

--- a/cmd/registry-experimental/cmd/generate/openapi.go
+++ b/cmd/registry-experimental/cmd/generate/openapi.go
@@ -25,9 +25,9 @@ import (
 
 	"github.com/apigee/registry/cmd/registry/compress"
 	"github.com/apigee/registry/cmd/registry/tasks"
-	"github.com/apigee/registry/cmd/registry/types"
 	"github.com/apigee/registry/pkg/connection"
 	"github.com/apigee/registry/pkg/log"
+	"github.com/apigee/registry/pkg/mime"
 	"github.com/apigee/registry/pkg/names"
 	"github.com/apigee/registry/pkg/visitor"
 	"github.com/apigee/registry/rpc"
@@ -109,15 +109,15 @@ func (task *generateOpenAPITask) Run(ctx context.Context) error {
 	relation := task.newSpecID
 	var openapi string
 	switch {
-	case types.IsOpenAPIv2(spec.GetMimeType()) || types.IsOpenAPIv3(spec.GetMimeType()):
+	case mime.IsOpenAPIv2(spec.GetMimeType()) || mime.IsOpenAPIv3(spec.GetMimeType()):
 		return nil
-	case types.IsProto(spec.GetMimeType()) && types.IsZipArchive(spec.GetMimeType()):
+	case mime.IsProto(spec.GetMimeType()) && mime.IsZipArchive(spec.GetMimeType()):
 		log.FromContext(ctx).Debugf("Computing %s/specs/%s", spec.Name, relation)
 		openapi, err = openAPIFromZippedProtos(ctx, spec.Name, data)
 		if err != nil {
 			return fmt.Errorf("error processing protos %s: %s", spec.Name, err)
 		}
-	case types.IsDiscovery(spec.GetMimeType()):
+	case mime.IsDiscovery(spec.GetMimeType()):
 		log.FromContext(ctx).Debugf("Computing %s/specs/%s", spec.Name, relation)
 		openapi, err = openAPIFromDiscovery(ctx, spec.Name, data)
 		if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	cloud.google.com/go/pubsub v1.25.1
 	github.com/GoogleCloudPlatform/cloudsql-proxy v1.32.0
 	github.com/apex/log v1.9.0
-	github.com/apigee/registry v0.6.4
+	github.com/apigee/registry v0.6.5-0.20230223005634-9d9e8a3b452f
 	github.com/blevesearch/bleve v1.0.14
 	github.com/envoyproxy/go-control-plane v0.10.2-0.20220325020618-49ff273808a1
 	github.com/gogo/googleapis v1.4.1

--- a/go.sum
+++ b/go.sum
@@ -92,6 +92,8 @@ github.com/aphistic/golf v0.0.0-20180712155816-02c07f170c5a/go.mod h1:3NqKYiepwy
 github.com/aphistic/sweet v0.2.0/go.mod h1:fWDlIh/isSE9n6EPsRmC0det+whmX6dJid3stzu0Xys=
 github.com/apigee/registry v0.6.4 h1:nSktx2XrrLJ+WWKszU/prtcQtQffohi+XQpqqveiKFI=
 github.com/apigee/registry v0.6.4/go.mod h1:u2fzmGZUuWcaT3byNfkJAAcGeqSmt2XQ20Xu8xSmsGk=
+github.com/apigee/registry v0.6.5-0.20230223005634-9d9e8a3b452f h1:icPi8hmiGWZwX3Dqvb8/+p3cUdt8o3CMerceRh9cwO0=
+github.com/apigee/registry v0.6.5-0.20230223005634-9d9e8a3b452f/go.mod h1:u2fzmGZUuWcaT3byNfkJAAcGeqSmt2XQ20Xu8xSmsGk=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/aws/aws-sdk-go v1.20.6/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aybabtme/rgbterm v0.0.0-20170906152045-cc83f3b3ce59/go.mod h1:q/89r3U2H7sSsE2t6Kca0lfwTK8JdoNGS/yzM/4iH5I=


### PR DESCRIPTION
This just gets everything building and passing tests. YAML serialization wasn't (but could be later) updated to use the functions in `pkg/encoding`.