### PR TITLE
Update api-linter styleguide generator to include "https://" in rule URIs.

### DIFF
--- a/lint/api-linter-styleguide-generator/generate.py
+++ b/lint/api-linter-styleguide-generator/generate.py
@@ -63,7 +63,7 @@ class StyleGuideGenerator(object):
                             "linter": "api-linter",
                             "linter_rulename": "::".join([e.strip() for e in parsed_yaml["rule"]["name"]]),
                             "severity": "ERROR",
-                            "doc_uri" : "linter.aip.dev"+parsed_yaml["permalink"].strip()
+                            "doc_uri" : "https://linter.aip.dev"+parsed_yaml["permalink"].strip()
                         }
                     )
                 except Exception as e:


### PR DESCRIPTION
This was probably an error from the start -- we should expect URIs in style guides to be valid URIs. I noticed this when I started displaying these in the viewer.