### PR TITLE
Add gateway label and spec to APIs imported from API Gateway.

### DIFF
--- a/cmd/registry-connect/discover/apigateway/gateways/gateways.go
+++ b/cmd/registry-connect/discover/apigateway/gateways/gateways.go
@@ -230,11 +230,15 @@ func writeRegistryYAML(output, project string, gateway *Gateway, config *Gateway
 					Header: encoding.Header{
 						Metadata: encoding.Metadata{
 							Name: "gateway",
+							Labels: map[string]string{
+								"apihub-gateway": "apihub-google-cloud-api-gateway",
+							},
 						},
 					},
 					Data: encoding.ApiDeploymentData{
-						DisplayName: "gateway",
-						EndpointURI: "https://" + gateway.DefaultHostname,
+						DisplayName:     "gateway",
+						ApiSpecRevision: "v1/specs/" + specname,
+						EndpointURI:     "https://" + gateway.DefaultHostname,
 					},
 				},
 			},


### PR DESCRIPTION
This needs https://github.com/apigee/registry/pull/1079 since the spec references in YAML don't include revision IDs.