### PR TITLE
Move vocabulary operations here from the registry tool, add stems and similarity subcommands.

### DIFF
--- a/cmd/registry-experimental/cmd/root.go
+++ b/cmd/registry-experimental/cmd/root.go
@@ -21,6 +21,7 @@ import (
 	"github.com/apigee/registry-experimental/cmd/registry-experimental/cmd/export"
 	"github.com/apigee/registry-experimental/cmd/registry-experimental/cmd/extract"
 	"github.com/apigee/registry-experimental/cmd/registry-experimental/cmd/generate"
+	"github.com/apigee/registry-experimental/cmd/registry-experimental/cmd/vocabulary"
 	pkgconf "github.com/apigee/registry/pkg/config"
 	"github.com/spf13/cobra"
 )
@@ -43,5 +44,6 @@ func Command() *cobra.Command {
 	cmd.AddCommand(export.Command())
 	cmd.AddCommand(extract.Command())
 	cmd.AddCommand(generate.Command())
+	cmd.AddCommand(vocabulary.Command())
 	return cmd
 }

--- a/cmd/registry-experimental/cmd/vocabulary/difference.go
+++ b/cmd/registry-experimental/cmd/vocabulary/difference.go
@@ -1,0 +1,58 @@
+// Copyright 2020 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vocabulary
+
+import (
+	"fmt"
+
+	"github.com/apigee/registry/pkg/connection"
+	"github.com/apigee/registry/pkg/log"
+	"github.com/google/gnostic/metrics/vocabulary"
+	"github.com/spf13/cobra"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+func differenceCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "difference",
+		Short: "Compute the difference of specified API vocabularies",
+		Args:  cobra.MinimumNArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			ctx := cmd.Context()
+			filter, err := cmd.Flags().GetString("filter")
+			if err != nil {
+				log.FromContext(ctx).WithError(err).Fatal("Failed to get filter from flags")
+			}
+			output, err := cmd.Flags().GetString("output")
+			if err != nil {
+				log.FromContext(ctx).WithError(err).Fatal("Failed to get output from flags")
+			}
+			client, err := connection.NewRegistryClient(ctx)
+			if err != nil {
+				log.FromContext(ctx).WithError(err).Fatal("Failed to get client")
+			}
+			_, inputs := collectInputVocabularies(ctx, client, args, filter)
+			vocab := vocabulary.Difference(inputs)
+			if output != "" {
+				setVocabularyToArtifact(ctx, client, vocab, output)
+			} else {
+				fmt.Println(protojson.Format((vocab)))
+			}
+		},
+	}
+
+	cmd.Flags().String("output", "", "artifact name to use when saving the vocabulary artifact")
+	return cmd
+}

--- a/cmd/registry-experimental/cmd/vocabulary/intersection.go
+++ b/cmd/registry-experimental/cmd/vocabulary/intersection.go
@@ -1,0 +1,58 @@
+// Copyright 2020 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vocabulary
+
+import (
+	"fmt"
+
+	"github.com/apigee/registry/pkg/connection"
+	"github.com/apigee/registry/pkg/log"
+	"github.com/google/gnostic/metrics/vocabulary"
+	"github.com/spf13/cobra"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+func intersectionCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "intersection",
+		Short: "Compute the intersection of specified API vocabularies",
+		Args:  cobra.MinimumNArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			ctx := cmd.Context()
+			filter, err := cmd.Flags().GetString("filter")
+			if err != nil {
+				log.FromContext(ctx).WithError(err).Fatal("Failed to get filter from flags")
+			}
+			output, err := cmd.Flags().GetString("output")
+			if err != nil {
+				log.FromContext(ctx).WithError(err).Fatal("Failed to get output from flags")
+			}
+			client, err := connection.NewRegistryClient(ctx)
+			if err != nil {
+				log.FromContext(ctx).WithError(err).Fatal("Failed to get client")
+			}
+			_, inputs := collectInputVocabularies(ctx, client, args, filter)
+			vocab := vocabulary.Intersection(inputs)
+			if output != "" {
+				setVocabularyToArtifact(ctx, client, vocab, output)
+			} else {
+				fmt.Println(protojson.Format((vocab)))
+			}
+		},
+	}
+
+	cmd.Flags().String("output", "", "artifact name to use when saving the vocabulary artifact")
+	return cmd
+}

--- a/cmd/registry-experimental/cmd/vocabulary/similarity.go
+++ b/cmd/registry-experimental/cmd/vocabulary/similarity.go
@@ -1,0 +1,127 @@
+// Copyright 2023 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vocabulary
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/apigee/registry/pkg/connection"
+	"github.com/apigee/registry/pkg/log"
+	"github.com/apigee/registry/pkg/mime"
+	"github.com/apigee/registry/pkg/names"
+	"github.com/apigee/registry/pkg/visitor"
+	"github.com/apigee/registry/rpc"
+	metrics "github.com/google/gnostic/metrics"
+	"github.com/spf13/cobra"
+	"google.golang.org/protobuf/proto"
+	"gopkg.in/yaml.v3"
+)
+
+func similarityCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "similarity VOCABULARY1 VOCABULARY2",
+		Short: "Compute similarity of two vocabularies",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			c, err := connection.ActiveConfig()
+			if err != nil {
+				return err
+			}
+			name1 := c.FQName(args[0])
+			name2 := c.FQName(args[1])
+
+			client, err := connection.NewRegistryClient(ctx)
+			if err != nil {
+				return err
+			}
+			artifactName1, err := names.ParseArtifact(name1)
+			if err != nil {
+				return err
+			}
+			artifactName2, err := names.ParseArtifact(name2)
+			if err != nil {
+				return err
+			}
+			counts := make(map[string]int32)
+			total := 0
+
+			for _, artifactName := range []names.Artifact{
+				artifactName1, artifactName2,
+			} {
+				err = visitor.GetArtifact(ctx, client, artifactName, true,
+					func(ctx context.Context, artifact *rpc.Artifact) error {
+						messageType, err := mime.MessageTypeForMimeType(artifact.GetMimeType())
+						if err != nil || messageType != "gnostic.metrics.Vocabulary" {
+							log.Debugf(ctx, "Skipping, not a vocabulary: %s", artifact.Name)
+							return nil
+						}
+						vocab := &metrics.Vocabulary{}
+						if err := proto.Unmarshal(artifact.GetContents(), vocab); err != nil {
+							log.FromContext(ctx).WithError(err).Debug("Failed to unmarshal contents")
+							return nil
+						}
+						for _, wordlist := range [][]*metrics.WordCount{
+							vocab.Operations,
+							vocab.Schemas,
+							vocab.Parameters,
+							vocab.Properties,
+						} {
+							total += len(wordlist)
+							for _, pair := range wordlist {
+								counts[pair.Word] += pair.Count
+							}
+						}
+						return nil
+					})
+				if err != nil {
+					return err
+				}
+			}
+
+			type Metric struct {
+				Total      int     `yaml:"total"`
+				Merged     int     `yaml:"merged"`
+				Common     int     `yaml:"common"`
+				Similarity float32 `yaml:"similarity"`
+			}
+			// a = words unique to v1
+			// b = words unique to v2
+			// c = words common to v1 and v2
+			// total = a + b + 2 * c
+			// merged = a + b + c
+			// total - merged = c
+			// similarity = 2*c / total
+			var m Metric
+			m.Total = total
+			m.Merged = len(counts)
+			m.Common = m.Total - m.Merged
+			m.Similarity = 2.0 * float32(m.Common) / float32(m.Total)
+			b, err := yaml.Marshal(m)
+			if err != nil {
+				return err
+			}
+			var concise = true
+			if concise {
+				_, err = fmt.Fprintf(cmd.OutOrStdout(), "%f", m.Similarity)
+			} else {
+				_, err = cmd.OutOrStdout().Write(b)
+			}
+			return err
+		},
+	}
+	return cmd
+}

--- a/cmd/registry-experimental/cmd/vocabulary/stems.go
+++ b/cmd/registry-experimental/cmd/vocabulary/stems.go
@@ -1,0 +1,130 @@
+// Copyright 2023 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vocabulary
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/apigee/registry/pkg/connection"
+	"github.com/apigee/registry/pkg/log"
+	"github.com/apigee/registry/pkg/mime"
+	"github.com/apigee/registry/pkg/names"
+	"github.com/apigee/registry/pkg/visitor"
+	"github.com/apigee/registry/rpc"
+	"github.com/fatih/camelcase"
+	metrics "github.com/google/gnostic/metrics"
+	"github.com/kljensen/snowball"
+	"github.com/spf13/cobra"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+)
+
+func stemsCommand() *cobra.Command {
+	var outputID string
+	cmd := &cobra.Command{
+		Use:   "stems",
+		Short: "Compute stems for words in specified vocabularies",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			ctx := cmd.Context()
+			c, err := connection.ActiveConfig()
+			if err != nil {
+				log.FromContext(ctx).WithError(err).Fatal("Failed to get config")
+			}
+			pattern := c.FQName(args[0])
+			filter, err := cmd.Flags().GetString("filter")
+			if err != nil {
+				log.FromContext(ctx).WithError(err).Fatal("Failed to get filter from flags")
+			}
+
+			if strings.Contains(outputID, "/") {
+				log.Fatal(ctx, "output-id must specify an artifact id (final segment only) and not a full name.")
+			}
+
+			client, err := connection.NewRegistryClient(ctx)
+			if err != nil {
+				log.FromContext(ctx).WithError(err).Fatal("Failed to get client")
+			}
+
+			patternName, err := names.ParseArtifact(pattern)
+			if err != nil {
+				log.FromContext(ctx).WithError(err).Fatal("Invalid pattern")
+			}
+
+			err = visitor.ListArtifacts(ctx, client, patternName, filter, true, func(ctx context.Context, artifact *rpc.Artifact) error {
+				messageType, err := mime.MessageTypeForMimeType(artifact.GetMimeType())
+				if err != nil || messageType != "gnostic.metrics.Vocabulary" {
+					log.Debugf(ctx, "Skipping, not a vocabulary: %s", artifact.Name)
+					return nil
+				}
+
+				vocab := &metrics.Vocabulary{}
+				if err := proto.Unmarshal(artifact.GetContents(), vocab); err != nil {
+					log.FromContext(ctx).WithError(err).Debug("Failed to unmarshal contents")
+					return nil
+				}
+
+				counts := make(map[string]int32)
+				for _, wordlist := range [][]*metrics.WordCount{
+					vocab.Operations,
+					vocab.Schemas,
+					vocab.Parameters,
+					vocab.Properties,
+				} {
+					for _, pair := range wordlist {
+						words := camelcase.Split(pair.Word)
+						for _, w := range words {
+							w = strings.ToLower(w)
+							w, _ = snowball.Stem(w, "english", true)
+							// todo: exclude numbers and special characters
+							counts[w] += pair.Count
+						}
+					}
+				}
+				stems := make([]*metrics.WordCount, 0)
+				for k, v := range counts {
+					stems = append(stems, &metrics.WordCount{
+						Word:  k,
+						Count: v,
+					})
+				}
+				// sort in decreasing order
+				sort.Slice(stems, func(i, j int) bool {
+					return stems[i].Count > stems[j].Count
+				})
+				stemVocabulary := &metrics.Vocabulary{
+					Properties: stems,
+				}
+				if outputID != "" {
+					artifactName, _ := names.ParseArtifact(artifact.Name)
+					outputName := artifactName.Parent() + "/artifacts/" + outputID
+					setVocabularyToArtifact(ctx, client, stemVocabulary, outputName)
+				} else {
+					fmt.Println(protojson.Format((vocab)))
+				}
+				return nil
+			})
+			if err != nil {
+				log.FromContext(ctx).WithError(err).Fatal("Failed to list artifacts")
+			}
+		},
+	}
+
+	cmd.Flags().StringVar(&outputID, "output-id", "stems", "artifact ID to use when saving each result vocabulary")
+	return cmd
+}

--- a/cmd/registry-experimental/cmd/vocabulary/union.go
+++ b/cmd/registry-experimental/cmd/vocabulary/union.go
@@ -1,0 +1,58 @@
+// Copyright 2020 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vocabulary
+
+import (
+	"fmt"
+
+	"github.com/apigee/registry/pkg/connection"
+	"github.com/apigee/registry/pkg/log"
+	"github.com/google/gnostic/metrics/vocabulary"
+	"github.com/spf13/cobra"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+func unionCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "union",
+		Short: "Compute the union of specified API vocabularies",
+		Args:  cobra.MinimumNArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			ctx := cmd.Context()
+			filter, err := cmd.Flags().GetString("filter")
+			if err != nil {
+				log.FromContext(ctx).WithError(err).Fatal("Failed to get filter from flags")
+			}
+			output, err := cmd.Flags().GetString("output")
+			if err != nil {
+				log.FromContext(ctx).WithError(err).Fatal("Failed to get output from flags")
+			}
+			client, err := connection.NewRegistryClient(ctx)
+			if err != nil {
+				log.FromContext(ctx).WithError(err).Fatal("Failed to get client")
+			}
+			_, inputs := collectInputVocabularies(ctx, client, args, filter)
+			vocab := vocabulary.Union(inputs)
+			if output != "" {
+				setVocabularyToArtifact(ctx, client, vocab, output)
+			} else {
+				fmt.Println(protojson.Format((vocab)))
+			}
+		},
+	}
+
+	cmd.Flags().String("output", "", "artifact name to use when saving the vocabulary artifact")
+	return cmd
+}

--- a/cmd/registry-experimental/cmd/vocabulary/unique.go
+++ b/cmd/registry-experimental/cmd/vocabulary/unique.go
@@ -1,0 +1,65 @@
+// Copyright 2020 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vocabulary
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/apigee/registry/pkg/connection"
+	"github.com/apigee/registry/pkg/log"
+	"github.com/google/gnostic/metrics/vocabulary"
+	"github.com/spf13/cobra"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+func uniqueCommand() *cobra.Command {
+	var outputID string
+	cmd := &cobra.Command{
+		Use:   "unique",
+		Short: "Compute the unique subsets of each member of specified vocabularies",
+		Args:  cobra.MinimumNArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			ctx := cmd.Context()
+			filter, err := cmd.Flags().GetString("filter")
+			if err != nil {
+				log.FromContext(ctx).WithError(err).Fatal("Failed to get filter from flags")
+			}
+
+			if strings.Contains(outputID, "/") {
+				log.Fatal(ctx, "output-id must specify an artifact id (final segment only) and not a full name.")
+			}
+
+			client, err := connection.NewRegistryClient(ctx)
+			if err != nil {
+				log.FromContext(ctx).WithError(err).Fatal("Failed to get client")
+			}
+			names, inputs := collectInputVocabularies(ctx, client, args, filter)
+			list := vocabulary.FilterCommon(inputs)
+			if outputID != "" {
+				for i, unique := range list.Vocabularies {
+					outputArtifactName := filepath.Dir(names[i]) + "/" + outputID
+					setVocabularyToArtifact(ctx, client, unique, outputArtifactName)
+				}
+			} else {
+				fmt.Println(protojson.Format((list)))
+			}
+		},
+	}
+
+	cmd.Flags().StringVar(&outputID, "output-id", "vocabulary-unique", "artifact ID to use when saving each result vocabulary")
+	return cmd
+}

--- a/cmd/registry-experimental/cmd/vocabulary/versions.go
+++ b/cmd/registry-experimental/cmd/vocabulary/versions.go
@@ -1,0 +1,64 @@
+// Copyright 2020 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vocabulary
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/apigee/registry/pkg/connection"
+	"github.com/apigee/registry/pkg/log"
+	"github.com/google/gnostic/metrics/vocabulary"
+	"github.com/spf13/cobra"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+func versionsCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "versions",
+		Short: "Compute the differences in API vocabularies associated with successive API versions",
+		Args:  cobra.MinimumNArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			ctx := cmd.Context()
+			filter, err := cmd.Flags().GetString("filter")
+			if err != nil {
+				log.FromContext(ctx).WithError(err).Fatal("Failed to get filter from flags")
+			}
+			output, err := cmd.Flags().GetString("output")
+			if err != nil {
+				log.FromContext(ctx).WithError(err).Fatal("Failed to get output from flags")
+			}
+			client, err := connection.NewRegistryClient(ctx)
+			if err != nil {
+				log.FromContext(ctx).WithError(err).Fatal("Failed to get client")
+			}
+			names, inputs := collectInputVocabularies(ctx, client, args, filter)
+
+			parts := strings.Split(names[0], "/")
+			parts = parts[0:4]
+			parent := strings.Join(parts, "/")
+
+			history := vocabulary.Version(inputs, names, parent)
+			if output != "" {
+				setVersionHistoryToArtifact(ctx, client, history, output)
+			} else {
+				fmt.Println(protojson.Format((history)))
+			}
+		},
+	}
+
+	cmd.Flags().String("output", "", "artifact name to use when saving the vocabulary artifact")
+	return cmd
+}

--- a/cmd/registry-experimental/cmd/vocabulary/vocabulary.go
+++ b/cmd/registry-experimental/cmd/vocabulary/vocabulary.go
@@ -1,0 +1,128 @@
+// Copyright 2020 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vocabulary
+
+import (
+	"context"
+	"strings"
+
+	"github.com/apigee/registry/cmd/registry/compress"
+	"github.com/apigee/registry/pkg/connection"
+	"github.com/apigee/registry/pkg/log"
+	"github.com/apigee/registry/pkg/mime"
+	"github.com/apigee/registry/pkg/names"
+	"github.com/apigee/registry/pkg/visitor"
+	"github.com/apigee/registry/rpc"
+	"github.com/spf13/cobra"
+	"google.golang.org/protobuf/proto"
+
+	metrics "github.com/google/gnostic/metrics"
+)
+
+func Command() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "vocabulary",
+		Short: "Operate on API vocabularies in the API Registry",
+	}
+
+	cmd.AddCommand(differenceCommand())
+	cmd.AddCommand(intersectionCommand())
+	cmd.AddCommand(similarityCommand())
+	cmd.AddCommand(stemsCommand())
+	cmd.AddCommand(unionCommand())
+	cmd.AddCommand(uniqueCommand())
+	cmd.AddCommand(versionsCommand())
+
+	cmd.PersistentFlags().String("filter", "", "Filter selected resources")
+	return cmd
+}
+
+func collectInputVocabularies(ctx context.Context, client connection.RegistryClient, args []string, filter string) ([]string, []*metrics.Vocabulary) {
+	c, err := connection.ActiveConfig()
+	if err != nil {
+		log.FromContext(ctx).WithError(err).Fatal("Failed to get config")
+	}
+
+	inputNames := make([]string, 0)
+	inputs := make([]*metrics.Vocabulary, 0)
+	for _, name := range args {
+		name = c.FQName(name)
+		artifact, err := names.ParseArtifact(name)
+		if err != nil {
+			continue
+		}
+
+		err = visitor.ListArtifacts(ctx, client, artifact, filter, true, func(ctx context.Context, artifact *rpc.Artifact) error {
+			messageType, err := mime.MessageTypeForMimeType(artifact.GetMimeType())
+			if err != nil || messageType != "gnostic.metrics.Vocabulary" {
+				log.Debugf(ctx, "Skipping, not a vocabulary: %s", artifact.Name)
+				return nil
+			}
+
+			vocab := &metrics.Vocabulary{}
+			if err := proto.Unmarshal(artifact.GetContents(), vocab); err != nil {
+				log.FromContext(ctx).WithError(err).Debug("Failed to unmarshal contents")
+				return nil
+			}
+
+			inputNames = append(inputNames, artifact.Name)
+			inputs = append(inputs, vocab)
+			return nil
+		})
+		if err != nil {
+			log.FromContext(ctx).WithError(err).Fatal("Failed to list artifacts")
+		}
+	}
+
+	return inputNames, inputs
+}
+
+func setVocabularyToArtifact(ctx context.Context, client connection.RegistryClient, output *metrics.Vocabulary, outputArtifactName string) {
+	parts := strings.Split(outputArtifactName, "/artifacts/")
+	subject := parts[0]
+	relation := parts[1]
+	messageData, _ := proto.Marshal(output)
+	var err error
+	messageData, err = compress.GZippedBytes(messageData)
+	if err != nil {
+		log.FromContext(ctx).WithError(err).Fatal("Failed to compress artifact")
+	}
+	log.Debugf(ctx, "Saving vocabulary data (%d bytes)", len(messageData))
+	artifact := &rpc.Artifact{
+		Name:     subject + "/artifacts/" + relation,
+		MimeType: mime.MimeTypeForMessageType("gnostic.metrics.Vocabulary+gzip"),
+		Contents: messageData,
+	}
+	err = visitor.SetArtifact(ctx, client, artifact)
+	if err != nil {
+		log.FromContext(ctx).WithError(err).Fatal("Failed to save artifact")
+	}
+}
+
+func setVersionHistoryToArtifact(ctx context.Context, client connection.RegistryClient, output *metrics.VersionHistory, outputArtifactName string) {
+	parts := strings.Split(outputArtifactName, "/artifacts/")
+	subject := parts[0]
+	relation := parts[1]
+	messageData, _ := proto.Marshal(output)
+	artifact := &rpc.Artifact{
+		Name:     subject + "/artifacts/" + relation,
+		MimeType: mime.MimeTypeForMessageType("gnostic.metrics.VersionHistory"),
+		Contents: messageData,
+	}
+	err := visitor.SetArtifact(ctx, client, artifact)
+	if err != nil {
+		log.FromContext(ctx).WithError(err).Fatal("Failed to save artifact")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/apigee/registry v0.6.8
 	github.com/blevesearch/bleve v1.0.14
 	github.com/envoyproxy/go-control-plane v0.10.2-0.20220325020618-49ff273808a1
+	github.com/fatih/camelcase v1.0.0
 	github.com/gogo/googleapis v1.4.1
 	github.com/golang/protobuf v1.5.2
 	github.com/google/gnostic v0.6.9
@@ -20,6 +21,7 @@ require (
 	github.com/googleapis/gax-go/v2 v2.5.1
 	github.com/graphql-go/graphql v0.8.0
 	github.com/graphql-go/handler v0.2.3
+	github.com/kljensen/snowball v0.6.0
 	github.com/spf13/cobra v1.5.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.13.0

--- a/go.sum
+++ b/go.sum
@@ -186,6 +186,8 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7
 github.com/facebookgo/ensure v0.0.0-20200202191622-63f1cf65ac4c/go.mod h1:Yg+htXGokKKdzcwhuNDwVvN+uBxDGXJ7G/VN1d8fa64=
 github.com/facebookgo/stack v0.0.0-20160209184415-751773369052/go.mod h1:UbMTZqLaRiH3MsBH8va0n7s1pQYcu3uTb8G4tygF4Zg=
 github.com/facebookgo/subset v0.0.0-20200203212716-c811ad88dec4/go.mod h1:5tD+neXqOorC30/tWg0LCSkrqj/AR6gu8yY8/fpw1q0=
+github.com/fatih/camelcase v1.0.0 h1:hxNvNX/xYBp0ovncs8WyWZrOrpBNub/JfaMvbURyft8=
+github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/flowstack/go-jsonschema v0.1.1/go.mod h1:yL7fNggx1o8rm9RlgXv7hTBWxdBM0rVwpMwimd3F3N0=
 github.com/frankban/quicktest v1.14.3 h1:FJKSZTDHjyhriyC81FLQ0LY93eSai0ZyR/ZIkd3ZUKE=
@@ -396,6 +398,7 @@ github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/kljensen/snowball v0.6.0 h1:6DZLCcZeL0cLfodx+Md4/OLC6b/bfurWUOUGs1ydfOU=
 github.com/kljensen/snowball v0.6.0/go.mod h1:27N7E8fVU5H68RlUmnWwZCfxgt4POBJfENGMvNRhldw=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=


### PR DESCRIPTION
Most of the new files in this PR were directly copied from the `registry` tool, where I would like to remove them.

These `vocabulary` subcommands perform interesting operations on vocabularies which at least currently, seem too experimental for the main `registry` tool. They compute things like intersections, unions, differences, and unique subsets of vocabularies.

This also includes two more experimental subcommands:
- `registry-experimental vocabulary stems`, which computes stems for all words in a vocabulary after first breaking camel-case and dotted strings into their basic "word" components. It might be useful to have a direct artifact representation of stems, this command currently stores these stems in a vocabulary in an arbitrarily-chosen one of the four sections ("properties"). Stems might be stored in an artifact with artifact id `stems`.
- `registry-experimental vocabulary similarity`, which computes the similarity of two stem lists. The similarity of a pair of stem lists is computed as the number of common words divided by the mean of their sizes, or `2*c/t`, where `c` is the number of common words and `t` the total number of words in both stem lists. For a collection of 40 Twilio APIs, this [produced this matrix of similarities](https://docs.google.com/spreadsheets/d/1CliSkKEsUxOCTN3HmDb7mdArnX4A45FCpbLYxOaqjF8/edit#gid=2109031136) (the lower diagonal is omitted because the full matrix is symmetric).

There's much more to do to see if this is accurate or useful, but this can help us explore that further.