### PR TITLE
Enhance "vocabulary similarity" to produce a csv of similarities for a group of stem lists.

### DIFF
--- a/cmd/registry-experimental/cmd/vocabulary/similarity.go
+++ b/cmd/registry-experimental/cmd/vocabulary/similarity.go
@@ -105,14 +105,18 @@ func similarityCommand() *cobra.Command {
 							}
 						}
 					}
-					// a = words unique to v1
-					// b = words unique to v2
-					// c = words common to v1 and v2
-					// total = a + b + 2 * c
-					// merged = a + b + c // this is the number of entries in the "counts" map
-					merged := len(counts)
-					// total - merged = c
-					common := total - merged
+					// Here we are using a map that collects the total number of unique words
+					// to find the number of words that are common to two collections.
+					// Why does this work?
+					// 		u1 = the number of words unique to v1
+					// 		u2 = the number of words unique to v2
+					// 		 c = the number of words common to v1 and v2
+					// The number of unique words (the size of the map) is unique = u1 + u2 + c.
+					unique := len(counts)
+					// The total number of words in both maps is total = u1 + u2 + 2*c.
+					// The number of words in common is total - merged = c.
+					common := total - unique
+					// We evaluate similarity as the fraction of all words that are shared.
 					// similarity = 2*c / total
 					similarity := 2.0 * float32(common) / float32(total)
 					fmt.Fprintf(cmd.OutOrStdout(), "%1.3f,", similarity)

--- a/cmd/registry-experimental/cmd/vocabulary/similarity.go
+++ b/cmd/registry-experimental/cmd/vocabulary/similarity.go
@@ -27,101 +27,107 @@ import (
 	metrics "github.com/google/gnostic/metrics"
 	"github.com/spf13/cobra"
 	"google.golang.org/protobuf/proto"
-	"gopkg.in/yaml.v3"
 )
+
+var filter string
 
 func similarityCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "similarity VOCABULARY1 VOCABULARY2",
-		Short: "Compute similarity of two vocabularies",
-		Args:  cobra.ExactArgs(2),
+		Use:   "similarity PATTERN1...",
+		Short: "Compute similarities of vocabularies",
+		Args:  cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			c, err := connection.ActiveConfig()
 			if err != nil {
 				return err
 			}
-			name1 := c.FQName(args[0])
-			name2 := c.FQName(args[1])
-
 			client, err := connection.NewRegistryClient(ctx)
 			if err != nil {
 				return err
 			}
-			artifactName1, err := names.ParseArtifact(name1)
-			if err != nil {
-				return err
-			}
-			artifactName2, err := names.ParseArtifact(name2)
-			if err != nil {
-				return err
-			}
-			counts := make(map[string]int32)
-			total := 0
-
-			for _, artifactName := range []names.Artifact{
-				artifactName1, artifactName2,
-			} {
-				err = visitor.GetArtifact(ctx, client, artifactName, true,
-					func(ctx context.Context, artifact *rpc.Artifact) error {
-						messageType, err := mime.MessageTypeForMimeType(artifact.GetMimeType())
+			vocabularyArtifacts := make([]*rpc.Artifact, 0)
+			for _, p := range args {
+				pattern := c.FQName(p)
+				name, err := names.ParseArtifact(pattern)
+				if err != nil {
+					return err
+				}
+				if err = visitor.ListArtifacts(ctx, client,
+					name,
+					filter,
+					true, func(ctx context.Context, message *rpc.Artifact) error {
+						messageType, err := mime.MessageTypeForMimeType(message.GetMimeType())
 						if err != nil || messageType != "gnostic.metrics.Vocabulary" {
-							log.Debugf(ctx, "Skipping, not a vocabulary: %s", artifact.Name)
+							log.Debugf(ctx, "Skipping, not a vocabulary: %s", message.Name)
 							return nil
 						}
-						vocab := &metrics.Vocabulary{}
-						if err := proto.Unmarshal(artifact.GetContents(), vocab); err != nil {
-							log.FromContext(ctx).WithError(err).Debug("Failed to unmarshal contents")
-							return nil
-						}
+						vocabularyArtifacts = append(vocabularyArtifacts, message)
+						return nil
+					}); err != nil {
+					return err
+				}
+			}
+
+			fmt.Fprintf(cmd.OutOrStdout(), ",")
+			for i := 0; i < len(vocabularyArtifacts); i++ {
+				fmt.Fprintf(cmd.OutOrStdout(), "%s,", shortName(vocabularyArtifacts[i].Name))
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "\n")
+			for i := 0; i < len(vocabularyArtifacts); i++ {
+				vi := &metrics.Vocabulary{}
+				if err := proto.Unmarshal(vocabularyArtifacts[i].GetContents(), vi); err != nil {
+					log.FromContext(ctx).WithError(err).Debug("Failed to unmarshal contents")
+					return nil
+				}
+				fmt.Fprintf(cmd.OutOrStdout(), "%s,", shortName(vocabularyArtifacts[i].Name))
+				for j := 0; j < i; j++ {
+					fmt.Fprintf(cmd.OutOrStdout(), "%1.3f,", 0.0)
+				}
+				for j := i; j < len(vocabularyArtifacts); j++ {
+					vj := &metrics.Vocabulary{}
+					if err := proto.Unmarshal(vocabularyArtifacts[j].GetContents(), vj); err != nil {
+						log.FromContext(ctx).WithError(err).Debug("Failed to unmarshal contents")
+						return nil
+					}
+					counts := make(map[string]int32)
+					total := 0
+					for _, v := range []*metrics.Vocabulary{vi, vj} {
 						for _, wordlist := range [][]*metrics.WordCount{
-							vocab.Operations,
-							vocab.Schemas,
-							vocab.Parameters,
-							vocab.Properties,
+							v.Operations,
+							v.Schemas,
+							v.Parameters,
+							v.Properties,
 						} {
 							total += len(wordlist)
 							for _, pair := range wordlist {
 								counts[pair.Word] += pair.Count
 							}
 						}
-						return nil
-					})
-				if err != nil {
-					return err
+					}
+					// a = words unique to v1
+					// b = words unique to v2
+					// c = words common to v1 and v2
+					// total = a + b + 2 * c
+					// merged = a + b + c // this is the number of entries in the "counts" map
+					merged := len(counts)
+					// total - merged = c
+					common := total - merged
+					// similarity = 2*c / total
+					similarity := 2.0 * float32(common) / float32(total)
+					fmt.Fprintf(cmd.OutOrStdout(), "%1.3f,", similarity)
 				}
-			}
-
-			type Metric struct {
-				Total      int     `yaml:"total"`
-				Merged     int     `yaml:"merged"`
-				Common     int     `yaml:"common"`
-				Similarity float32 `yaml:"similarity"`
-			}
-			// a = words unique to v1
-			// b = words unique to v2
-			// c = words common to v1 and v2
-			// total = a + b + 2 * c
-			// merged = a + b + c
-			// total - merged = c
-			// similarity = 2*c / total
-			var m Metric
-			m.Total = total
-			m.Merged = len(counts)
-			m.Common = m.Total - m.Merged
-			m.Similarity = 2.0 * float32(m.Common) / float32(m.Total)
-			b, err := yaml.Marshal(m)
-			if err != nil {
-				return err
-			}
-			var concise = true
-			if concise {
-				_, err = fmt.Fprintf(cmd.OutOrStdout(), "%f", m.Similarity)
-			} else {
-				_, err = cmd.OutOrStdout().Write(b)
+				fmt.Fprintf(cmd.OutOrStdout(), "%s", shortName(vocabularyArtifacts[i].Name))
+				fmt.Fprintf(cmd.OutOrStdout(), "\n")
 			}
 			return err
 		},
 	}
+	cmd.Flags().StringVar(&filter, "filter", "", "filter selected resources")
 	return cmd
+}
+
+func shortName(artifactName string) string {
+	name, _ := names.ParseArtifact(artifactName)
+	return name.ApiID() + "/" + name.VersionID()
 }


### PR DESCRIPTION
This makes it easier to compute and evaluate similarities for groups of API specs.

I've tested this on lists as large as 40, and although that was surprisingly fast (small number of minutes), watch out for the quadratic runtime of this - every stem list is compared with every other stem list.

```
% registry-experimental vocabulary similarity apis/-/versions/-/specs/protos/artifacts/stems --filter 'name.contains("speech")'            
,google.com-speech/v1,google.com-speech/v1p1beta1,google.com-speech/v2,google.com-texttospeech/v1,google.com-texttospeech/v1beta1,
google.com-speech/v1,1.000,0.991,0.856,0.720,0.715,google.com-speech/v1
google.com-speech/v1p1beta1,0.000,1.000,0.848,0.713,0.707,google.com-speech/v1p1beta1
google.com-speech/v2,0.000,0.000,1.000,0.704,0.699,google.com-speech/v2
google.com-texttospeech/v1,0.000,0.000,0.000,1.000,0.980,google.com-texttospeech/v1
google.com-texttospeech/v1beta1,0.000,0.000,0.000,0.000,1.000,google.com-texttospeech/v1beta1
```

![image](https://user-images.githubusercontent.com/405/224804271-71fd3d40-0a1f-4b3e-ae44-2fdb0bccc7db.png)
