### PR TITLE
Update README.md

### DIFF
--- a/containers/registry-spec-renderer/README.md
+++ b/containers/registry-spec-renderer/README.md
@@ -10,6 +10,8 @@ GRAPHQL_MOCK_ENDPOINT).
 
 [![Run on Google Cloud](https://deploy.cloud.run/button.svg)](https://deploy.cloud.run?dir=containers/registry-spec-renderer)
 
+_This is equivalent to running `gcloud run deploy --source containers/registry-spec-renderer` from the root of this repository._
+
 ### To run this service on a GCE instance run the following command:
 
 ```


### PR DESCRIPTION
Add the equivalent `cloud run build` command in case users are unable to use the button (due to Cloud Shell restrictions).