### PR TITLE
update `compute descriptor` to include dependencies and accept implicit project/locations

### DIFF
--- a/cmd/registry-experimental/cmd/compute/descriptor.go
+++ b/cmd/registry-experimental/cmd/compute/descriptor.go
@@ -45,24 +45,28 @@ func descriptorCommand() *cobra.Command {
 		Use:   "descriptor",
 		Short: "Compute descriptors of API specs",
 		Args:  cobra.ExactArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
+			c, err := connection.ActiveConfig()
+			if err != nil {
+				return err
+			}
+			pattern := c.FQName(args[0])
 
 			filter, err := cmd.Flags().GetString("filter")
 			if err != nil {
-				log.FromContext(ctx).WithError(err).Fatal("Failed to get filter from flags")
+				return err
 			}
 
 			client, err := connection.NewRegistryClient(ctx)
 			if err != nil {
-				log.FromContext(ctx).WithError(err).Fatal("Failed to get client")
+				return err
 			}
 			// Initialize task queue.
 			taskQueue, wait := tasks.WorkerPoolIgnoreError(ctx, 1)
 			defer wait()
 			// Generate tasks.
-			name := args[0]
-			if spec, err := names.ParseSpec(name); err == nil {
+			if spec, err := names.ParseSpec(pattern); err == nil {
 				err = visitor.ListSpecs(ctx, client, spec, filter, false, func(ctx context.Context, spec *rpc.ApiSpec) error {
 					taskQueue <- &computeDescriptorTask{
 						client:   client,
@@ -71,9 +75,10 @@ func descriptorCommand() *cobra.Command {
 					return nil
 				})
 				if err != nil {
-					log.FromContext(ctx).WithError(err).Fatal("Failed to list specs")
+					return err
 				}
 			}
+			return nil
 		},
 	}
 }
@@ -180,6 +185,7 @@ func generateDescriptorForDirectory(ctx context.Context, name string, root strin
 	args := []string{}
 	args = append(args, protos...)
 	args = append(args, "--proto_path=protos")
+	args = append(args, "--include_imports")
 	args = append(args, "--descriptor_set_out=proto.pb")
 	cmd := exec.Command("protoc", args...)
 	cmd.Dir = root


### PR DESCRIPTION
While working on a gRPC sample, I noticed that `compute descriptor` was still requiring project/location prefixes and was not including dependencies (`protoc --include_imports`), which is needed by many downstream tools (e.g. API Gateway). This fixes both and updates the command to use `RunE`.

Also, this command is not tested: #200