### PR TITLE
Fix flaky bleve server test

### DIFF
--- a/cmd/registry-experimental/cmd/bleve/bleve_test.go
+++ b/cmd/registry-experimental/cmd/bleve/bleve_test.go
@@ -210,7 +210,7 @@ func TestServer(t *testing.T) {
 	}()
 
 	// Wait for the server to start.
-	_, err := net.DialTimeout("tcp", "localhost:"+port, 2*time.Second)
+	_, err := net.DialTimeout("tcp", "localhost:"+port, 5*time.Second)
 	if err != nil {
 		log.Fatalf("Failed to connect to test server: %s", err)
 	}

--- a/cmd/registry-experimental/cmd/bleve/bleve_test.go
+++ b/cmd/registry-experimental/cmd/bleve/bleve_test.go
@@ -210,7 +210,8 @@ func TestServer(t *testing.T) {
 	}()
 
 	// Wait for the server to start.
-	_, err := net.DialTimeout("tcp", "localhost:"+port, 5*time.Second)
+	time.Sleep(1 * time.Second) // arbitrary pause
+	_, err := net.DialTimeout("tcp", "localhost:"+port, 2*time.Second)
 	if err != nil {
 		log.Fatalf("Failed to connect to test server: %s", err)
 	}


### PR DESCRIPTION
Investigating #218... tests were failing when `DialTimeout()` returns immediately with "connection refused". Increasing the timeout didn't help, and reviewing the timestamps in the log file, it was clear that the failure was immediate -- I'm guessing that the goroutine running the server hadn't even started, so when the connection was attempted it failed immediately because there was nothing to connect with. I suspect that `DialTimeout()` wasn't written for cases where the server hadn't been started yet but was instead intended to handle slow network connections and slow server responses.

Adding an explicit sleep allowed the test to pass on [all 3 of 3 attempts](https://github.com/apigee/registry-experimental/actions/runs/5649909055/job/15305371908?pr=219) (it was failing 1/2 to 2/3 of the time previously).